### PR TITLE
Adjust naming conventions to better suit our needs and add legacy toggle

### DIFF
--- a/assets/scss/3-resets/_all-legacy.scss
+++ b/assets/scss/3-resets/_all-legacy.scss
@@ -1,0 +1,7 @@
+// Resets (normalize)
+//
+// Deprecated: We paste in an old version of normalize as our base. It's around 8kb
+//
+// Styleguide 3.0.0
+@import 'box-sizing';
+@import 'normalize';

--- a/assets/scss/3-resets/_all-v2.scss
+++ b/assets/scss/3-resets/_all-v2.scss
@@ -1,8 +1,0 @@
-// Resets
-//
-// Experimental: We want to import normalize instead. It's around 6kb and we can update versions as https://github.com/necolas/normalize.css changes.
-//
-//
-// Styleguide 3.0.0
-@import 'box-sizing';
-@import 'normalize.css/normalize';

--- a/assets/scss/3-resets/_all.scss
+++ b/assets/scss/3-resets/_all.scss
@@ -1,7 +1,8 @@
-// Resets (normalize)
+// Resets
 //
-// Deprecated: We paste in an old version of normalize as our base. It's around 8kb
+// Experimental: We want to import normalize instead. It's around 6kb and we can update versions as https://github.com/necolas/normalize.css changes.
+//
 //
 // Styleguide 3.0.0
 @import 'box-sizing';
-@import 'normalize';
+@import 'normalize.css/normalize';

--- a/assets/scss/4-elements/_all-legacy.scss
+++ b/assets/scss/4-elements/_all-legacy.scss
@@ -1,3 +1,8 @@
+// Elements
+//
+// Set font root sizes for desktop, tablet, mobile
+//
+// Styleguide 4.0.0
 html {
   font-size: $font-root;
   @include mq($until: bp-s) {
@@ -27,6 +32,33 @@ h6,
 p {
   margin: 0;
   padding: 0;
+}
+
+// Set base typography proportions for headers, paragraphs, etc.
+// sizing variables in settings/_breakpoints.scss
+h1 {
+  font-size: $size-xxl;
+  line-height: 1.2;
+}
+
+h2 {
+  font-size: $size-xl;
+}
+
+h3 {
+  font-size: $size-l;
+}
+
+h4 {
+  font-size: $size-m;
+}
+
+h5 {
+  font-size: $size-s;
+}
+
+p {
+  font-size: $size-b;
 }
 
 a {

--- a/assets/scss/4-elements/_all.scss
+++ b/assets/scss/4-elements/_all.scss
@@ -1,8 +1,3 @@
-// Elements
-//
-// Set font root sizes for desktop, tablet, mobile
-//
-// Styleguide 4.0.0
 html {
   font-size: $font-root;
   @include mq($until: bp-s) {
@@ -32,33 +27,6 @@ h6,
 p {
   margin: 0;
   padding: 0;
-}
-
-// Set base typography proportions for headers, paragraphs, etc.
-// sizing variables in settings/_breakpoints.scss
-h1 {
-  font-size: $size-xxl;
-  line-height: 1.2;
-}
-
-h2 {
-  font-size: $size-xl;
-}
-
-h3 {
-  font-size: $size-l;
-}
-
-h4 {
-  font-size: $size-m;
-}
-
-h5 {
-  font-size: $size-s;
-}
-
-p {
-  font-size: $size-b;
 }
 
 a {

--- a/assets/scss/5-typography/_all-legacy.scss
+++ b/assets/scss/5-typography/_all-legacy.scss
@@ -1,0 +1,8 @@
+// Typography
+//
+// Classed based and non class based styles relating to type
+//
+// Styleguide 5.0.0
+@import 'font-families';
+@import 'font-awesome';
+@import 'typography-legacy';

--- a/assets/scss/5-typography/_all-v2.scss
+++ b/assets/scss/5-typography/_all-v2.scss
@@ -1,3 +1,0 @@
-@import 'font-families';
-@import 't-size';
-@import 'typography-v2';

--- a/assets/scss/5-typography/_all.scss
+++ b/assets/scss/5-typography/_all.scss
@@ -1,8 +1,3 @@
-// Typography
-//
-// Classed based and non class based styles relating to type
-//
-// Styleguide 5.0.0
 @import 'font-families';
-@import 'font-awesome';
-@import 'typography-legacy';
+@import 't-size';
+@import 'typography-v2';

--- a/assets/scss/6-components/_all.scss
+++ b/assets/scss/6-components/_all.scss
@@ -6,6 +6,9 @@
 @import 'ad/ad';
 @import 'back-to-top/back-to-top';
 @import 'button/button';
+@import 'ad/ad';
+@import 'back-to-top/back-to-top';
+@import 'button/button';
 @import 'card/card';
 @import 'icon/icon';
 @import 'loading/loading';

--- a/assets/scss/7-utilities/_all-legacy.scss
+++ b/assets/scss/7-utilities/_all-legacy.scss
@@ -1,0 +1,7 @@
+// Utility
+//
+// Helper overrides for various utilities. V2 will use prefixes of .l-, .has-, .is-
+//
+// Styleguide 7.0.0
+@import 'grid';
+@import 'layout';

--- a/assets/scss/7-utilities/_all-v2.scss
+++ b/assets/scss/7-utilities/_all-v2.scss
@@ -1,4 +1,0 @@
-@import 'color-helpers';
-@import 'grid';
-@import 'layout-v2';
-@import 'multicol';

--- a/assets/scss/7-utilities/_all.scss
+++ b/assets/scss/7-utilities/_all.scss
@@ -1,7 +1,4 @@
-// Utility
-//
-// Helper overrides for various utilities. V2 will use prefixes of .l-, .has-, .is-
-//
-// Styleguide 7.0.0
+@import 'color-helpers';
 @import 'grid';
-@import 'layout';
+@import 'layout-v2';
+@import 'multicol';

--- a/assets/scss/all-legacy.scss
+++ b/assets/scss/all-legacy.scss
@@ -1,0 +1,6 @@
+@import '1-settings/all';
+@import '2-tools/all';
+@import '3-resets/all-legacy';
+@import '4-elements/all-legacy';
+@import '5-typography/all-legacy';
+@import '7-utilities/all-legacy';

--- a/assets/scss/all.scss
+++ b/assets/scss/all.scss
@@ -3,4 +3,5 @@
 @import '3-resets/all';
 @import '4-elements/all';
 @import '5-typography/all';
+@import '6-components/all';
 @import '7-utilities/all';

--- a/assets/scss/base-v2.scss
+++ b/assets/scss/base-v2.scss
@@ -10,6 +10,9 @@
 @import '6-components/site-footer/site-footer';
 
 // To be removed after directory restructure (will also just rename this file to base.scss)
+@import '6-components/ad/ad';
+@import '6-components/back-to-top/back-to-top';
+@import '6-components/button/button';
 @import '6-components/card/card';
 @import '6-components/table/table';
 @import '6-components/tabs/tabs';

--- a/assets/scss/base-v2.scss
+++ b/assets/scss/base-v2.scss
@@ -1,7 +1,17 @@
 @import '1-settings/all';
 @import '2-tools/all';
-@import '3-resets/all-v2';
-@import '4-elements/all-v2';
-@import '5-typography/all-v2';
-@import '6-components/all';
-@import '7-utilities/all-v2';
+@import '3-resets/all';
+@import '4-elements/all';
+@import '5-typography/all';
+
+// Our base component set (minimum amount needed for getting started)
+@import '6-components/icon/icon';
+@import '6-components/navbar/navbar';
+@import '6-components/site-footer/site-footer';
+
+// To be removed after directory restructure (will also just rename this file to base.scss)
+@import '6-components/card/card';
+@import '6-components/table/table';
+@import '6-components/tabs/tabs';
+
+@import '7-utilities/all';

--- a/docs/build/build.js
+++ b/docs/build/build.js
@@ -1,6 +1,3 @@
-// utility
-const fs = require('fs-extra');
-
 // lib
 const stylesRunner = require('../../tasks/styles');
 const iconsRunner = require('../../tasks/icons');

--- a/docs/build/develop.js
+++ b/docs/build/develop.js
@@ -1,14 +1,7 @@
-// internal
-const { series, clearConsole } = require('../../tasks/utils');
-
-// tasks
-
 const watch = require('./watch');
 
 async function develop() {
-  // clearConsole();
   await watch();
 }
-
 
 develop().catch(console.error);

--- a/docs/build/paths.js
+++ b/docs/build/paths.js
@@ -4,12 +4,12 @@ const mappedStyles = [
     out: './docs/dist/css/ds.css',
   },
   {
-    in: './assets/scss/base-v2.scss',
-    out: './docs/dist/css/base-v2.css',
+    in: './assets/scss/all.scss',
+    out: './docs/dist/css/all.css',
   },
   {
-    in: './assets/scss/base.scss',
-    out: './docs/dist/css/base.css',
+    in: './assets/scss/all-legacy.scss',
+    out: './docs/dist/css/all-legacy.css',
   },
 ];
 

--- a/docs/build/watch.js
+++ b/docs/build/watch.js
@@ -5,6 +5,7 @@ const colors = require('ansi-colors');
 
 // lib
 const stylesRunner = require('../../tasks/styles');
+const copyRunner = require('../../tasks/copy');
 const {
   clearConsole,
   printInstructions,
@@ -12,7 +13,7 @@ const {
 } = require('../../tasks/utils');
 
 const docsRunner = require('./docs.js');
-const { mappedStyles } = require('./paths.js');
+const { mappedStyles, mappedCopies } = require('./paths.js');
 
 module.exports = async () => {
   // create the browser-sync client
@@ -91,6 +92,13 @@ module.exports = async () => {
           templatesError = err;
         }
 
+        try {
+          await copyRunner(mappedCopies);
+          templatesError = null;
+        } catch (err) {
+          templatesError = err;
+        }
+
         // if browsersync is active, reload it
         if (bs.active) {
           bs.reload();
@@ -109,6 +117,7 @@ module.exports = async () => {
           './assets/scss/**/*.scss',
           './docs/src/**/*.html',
           './docs/src/scss/**/*.scss',
+          './docs/src/js/**/*.js',
         ],
         compile
       );

--- a/docs/src/index.html
+++ b/docs/src/index.html
@@ -8,8 +8,8 @@
   <meta content="ie=edge" http-equiv="X-UA-Compatible" />
   <title>Document</title>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.2/css/bulma.min.css" rel="stylesheet" />
-  <link rel="stylesheet" href="css/base.css" />
-  <link rel="stylesheet" href="css/base-v2.css" />
+  <link rel="stylesheet" href="css/all-legacy.css" />
+  <link rel="stylesheet" href="css/all.css" />
   <link id="ds" rel="stylesheet" href="css/ds.css" />
 </head>
 
@@ -33,6 +33,9 @@
     <div class="tile is-ancestor">
       <div class="tile is-parent is-vertical is-3">
         <aside class="menu ds-stick-it">
+          <div class="box buttons has-text-centered">
+              <button class="button is-primary is-fullwidth" id="hideLegacy"><span class="ds-version-tag">Hide</span><span class="ds-version-tag--show">Show</span>&nbsp;Legacy</button>
+            </div>
           <p class="menu-label">
             Sections
           </p>
@@ -66,7 +69,7 @@
               <ul class="menu-list ds-spacer">      
               {% for rule in list %}
                 {% if rule.depth !== 1 %}
-                  <li><a href="pages/{{ slug + '/index.html#' + rule.slug }}">{{ rule.header }}</a></li>
+                  <li class="{% if rule.deprecated %} ds-legacy{% endif %}"><a href="pages/{{ slug + '/index.html#' + rule.slug }}">{{ rule.header }}</a></li>
                 {% endif %}
               {% endfor %}
               </ul>

--- a/docs/src/js/ds.js
+++ b/docs/src/js/ds.js
@@ -1,9 +1,3 @@
-// Add a simple sidebar toggle
-var container = document.querySelector('#content');
-var button = document.querySelector('#sidebarToggle');
-button.addEventListener('click', function() {
-  container.classList.toggle('ds-hide-sidebar');
-});
 // Add simple dropdown for Bulma dropdown component
 document.addEventListener('DOMContentLoaded', function() {
   // Dropdowns
@@ -34,35 +28,8 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 });
 
-var buttonLegacy = document.querySelector('#buttonLegacy');
-buttonLegacy.addEventListener('click', function() {
-  this.disabled = true;
-  document.getElementById('buttonV2').disabled = false;
-  changeCSS('base-v2', 'base');
+var hideLegacy = document.querySelector('#hideLegacy');
+hideLegacy.addEventListener('click', function() {
+  document.body.classList.toggle('js-ds-hide-legacy');
+  this.classList.toggle('is-active');
 });
-var buttonV2 = document.querySelector('#buttonV2');
-buttonV2.addEventListener('click', function() {
-  this.disabled = true;
-  document.getElementById('buttonLegacy').disabled = false;
-  changeCSS('base', 'base-v2');
-});
-var addLink = function(id) {
-  var link = document.createElement('link');
-  link.href = id + '.min.css';
-  link.id = id;
-  link.rel = 'stylesheet';
-  link.type = 'text/css'; // no need for HTML5
-  document.getElementsByTagName('head')[0].appendChild(link);
-};
-function changeCSS(cssFileOut, cssFileIn) {
-  var outEl = document.querySelector('#' + cssFileOut);
-  var inEl = document.querySelector('#' + cssFileIn);
-  if (outEl.parentNode) {
-    outEl.parentNode.removeChild(outEl);
-    document.getElementById('buttonToggle').textContent =
-      'Viewing ' + cssFileIn + '.css ONLY.';
-  }
-  if (!inEl) {
-    addLink(cssFileIn);
-  }
-}

--- a/docs/src/page.html
+++ b/docs/src/page.html
@@ -12,8 +12,8 @@
   <meta content="ie=edge" http-equiv="X-UA-Compatible" />
   <title>Document</title>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.2/css/bulma.min.css" rel="stylesheet" />
-  <link id="base" rel="stylesheet" href="../../css/base.css" />
-  <link id="base-v2" rel="stylesheet" href="../../css/base-v2.css" />
+  <link id="base" rel="stylesheet" href="../../css/all-legacy.css" />
+  <link id="base-v2" rel="stylesheet" href="../../css/all.css" />
   <link id="ds" rel="stylesheet" href="../../css/ds.css" />
 </head>
 
@@ -23,30 +23,22 @@
   </div>
   <div class="grid_container--xl">
     <div id="content" class="tile is-ancestor ds-content">
-      <!--<div class="ds-util">
-        <span class="subtitle is-size-6">Toggle CSS</span>
-        <div class="buttons has-addons ds-breathe is-centered">
-          <button id="buttonLegacy" class="button is-warning">V1</button>
-          <button id="buttonV2" class="button is-info">V2</button>
-        </div>
-        <div id="buttonToggle" class="is-size-7"></div>   
-      </div>-->
       <div class="tile is-parent is-vertical is-3 ds-sidebar">
         <aside class="menu ds-stick-it">
           <p class="menu-label">
             <div class="box buttons has-text-centered">
               <a href="../../index.html" class="button is-primary is-outlined is-fullwidth">< Back</a>
-              <button class="button is-primary is-outlined is-fullwidth" id="sidebarToggle">Toggle Menu</button>
+              <button class="button is-primary is-fullwidth" id="hideLegacy"><span class="ds-version-tag">Hide</span><span class="ds-version-tag--show">Show</span>&nbsp;Legacy</button>
             </div>
           </p>
           <ul class="menu-list ds-menu box has-background-light">
             {% for item in list %}
               {% if item.depth !== 1 %}
-              <li class="has-text-weight-bold">
+              <li class="has-text-weight-bold {% if item.deprecated %} ds-legacy{% endif %}">
                 <a class="" href="#{{ item.slug }}">
                 {{ item.prettyName }}
                 {% if item.experimental === true %}
-                  <span class="has-text-info">V2</span>
+                  <span class="has-text-info ds-version-tag">V2</span>
                 {% endif %}
                 </a>
               </li>
@@ -67,17 +59,17 @@
           {% set isTool = item.isTool %}
           {# <span class="ds-breathe"></span> #}
           {% if item.depth !== 1 %}
-          <div class="section ds-spacer">
+          <div class="section ds-spacer{% if item.deprecated %} ds-legacy{% endif %}">
             <a class="ds-anchor" id="{{ item.slug }}"></a>
             {{ titleBar(name, item) }}
             <div class="ds-breathe-vert">
               <h2 class="title is-{{ item.depth }}">
               {{ item.prettyName }}
               {% if item.experimental %}
-              <span class="tag is-info">V2</span>
+              <span class="tag is-info ds-version-tag">V2</span>
               {% endif %}
               {% if item.deprecated %}
-              <span class="tag is-warning">Legacy</span>
+              <span class="tag is-warning ds-version-tag">Legacy</span>
               {% endif %}
               </h2>
               <div class="subtitle ds-desc">
@@ -195,7 +187,7 @@
       </p>
     </div>
   </footer>
-  <script src="../js/ds.js"></script>
+  <script src="../../js/ds.js"></script>
 </body>
 
 </html>

--- a/docs/src/preview.html
+++ b/docs/src/preview.html
@@ -5,8 +5,8 @@
   <meta content="width=device-width, initial-scale=1.0" name="viewport" />
   <meta content="ie=edge" http-equiv="X-UA-Compatible" />
   <title>Document</title>
-  <link id="base" rel="stylesheet" href="../../css/base.css" />
-  <link id="base-v2" rel="stylesheet" href="../../css/base-v2.css" />
+  <link id="base" rel="stylesheet" href="../../css/all-legacy.css" />
+  <link id="base-v2" rel="stylesheet" href="../../css/all.css" />
   <link id="ds" rel="stylesheet" href="../../css/ds.css" />
 </head>
 <body>

--- a/docs/src/scss/ds.scss
+++ b/docs/src/scss/ds.scss
@@ -134,3 +134,18 @@ strong {
   width: 100%;
   height: 95vh;
 }
+
+.ds-version-tag {
+  &--show {
+    display: none; 
+    
+    .js-ds-hide-legacy & {
+      display: inline;
+    }
+  }
+}
+
+.js-ds-hide-legacy .ds-legacy,
+.js-ds-hide-legacy .ds-version-tag {
+  display: none;
+}


### PR DESCRIPTION
These file changes are a little misleading so here are the high level changes:

New world
- Uses `assets/{{ subfolder }}/_all.scss` in each sub folder
- Uses `assets/base-v2.scss` for our "just to get you started base"*
- Uses `assets/all.scss` for our "I just want everything file"

*We'll rename this to just `base.scss` after we're done moving files around in the main repo

Old world (now always prefixed with legacy)
- Uses `assets/{{ subfolder }}/_all-legacy.scss` in each sub folder
- Doesn't have a "just to get you started base"
- Uses `assets/all-legacy.scss` for our "I just want everything _from legacy_ file "

I also added an ability to streamline your view in the docs to filter out the legacy that I find myself needing less and less. One day I think we just stop displaying docs from the old world.