### PR TITLE
Linting, helper indicator, and cleanup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: 'https://github.com/prettier/prettier'
+    rev: 1.15.3
+    hooks:
+    -   id: prettier
+        files: '/.*\.(js$)'
+  - repo: 'https://github.com/awebdeveloper/pre-commit-stylelint'
+    sha: 'c4c991cd38b0218735858716b09924f8b20e3812'
+    hooks:
+    -   id: stylelint
+        additional_dependencies: ['stylelint@9.10.1']
+        files: '/.*\.(scss$)'

--- a/README.md
+++ b/README.md
@@ -17,14 +17,37 @@ yarn start
 
 
 ## To Dos
-* [ ] Watch task
+* [x] Watch task
 * [ ] Actions/Versioning and Deploy visual output to URL[https://medium.com/devopslinks/automate-your-npm-publish-with-github-actions-dfe8059645dd] rules
-* [ ] Pre commit linting
+* [x] Pre commit linting
 * [ ] File size tracker
 * [ ] Component status tracker
 * [ ] Accessibility compliance checking
 * [ ] Make VS code comment snippet
-* [ ] Fix code preview and GitHub search feature
+* [x] Fix code preview
+* [ ] GitHub search feature
 * [ ] Way to easily build universal stylesheet
 * [ ] Way to easily build universal sprite
 * [ ] Allow for hiding main demo
+
+
+
+## SCSS docs boilerplate
+
+We use a comment parser along with some [extra logic](https://github.com/texastribune/ds-toolbox/blob/master/tasks/style-doc.js) to generate our docs. To add a new section of documentation, add a boilerplate above your CSS rules like the one below: 
+
+```scss
+// Title of Section (root-class-name)
+//
+// Description {{isWide}} {{isHelper}}
+//
+// root-class-name-modifier - desc
+//
+// Markup: 6-components/test/test.html
+//
+// Styleguide 6.0.1
+//
+.root-class-name {
+  
+}
+```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ yarn start
 * [ ] GitHub search feature
 * [ ] Way to easily build universal stylesheet
 * [ ] Way to easily build universal sprite
-* [ ] Allow for hiding main demo
+* [x] Allow for hiding main demo
 
 
 
@@ -51,3 +51,5 @@ We use a comment parser along with some [extra logic](https://github.com/texastr
   
 }
 ```
+- `{{isWide}}` is used to display the demo of each modifier at full width
+- `{{isHelper}}` is used to hide main demo and only display modifiers

--- a/assets/scss/5-typography/_t-size.scss
+++ b/assets/scss/5-typography/_t-size.scss
@@ -18,21 +18,8 @@
 //
 // Styleguide 5.2.7
 //
-$type-sizes: (
-  xxxl: $size-xxxl,
-  giant: $size-giant,
-  xxl: $size-xxl,
-  xl: $size-xl,
-  l: $size-l,
-  m: $size-m,
-  b: $size-b,
-  s: $size-s,
-  xs: $size-xs,
-  xxs: $size-xxs,
-  xxxs: $size-xxxs,
-);
 
-@each $type-set, $font-size in $type-sizes {
+@each $type-set, $font-size in $size-map {
   .t-size-#{$type-set} {
     font-size: $font-size;
   }

--- a/assets/scss/5-typography/_t-size.scss
+++ b/assets/scss/5-typography/_t-size.scss
@@ -1,6 +1,6 @@
 // Text size (t-size)
 //
-// Experimental: New utility to help eliminate repitition.
+// Experimental: New utility to help eliminate repitition. {{isHelper}}
 //
 // .t-size-xxxs - XXXS Text size
 // .t-size-xxs - XXS Text size

--- a/assets/scss/5-typography/_typography-v2.scss
+++ b/assets/scss/5-typography/_typography-v2.scss
@@ -19,7 +19,7 @@
 
 // Text Case (t-case)
 //
-// Experimental: Adds new naming convention
+// Experimental: Adds new naming convention {{isHelper}}
 //
 // .t-titlecase - Text transformed to Title Case
 // .t-uppercase - Text transformed to UPPERCASE
@@ -48,7 +48,7 @@
 
 // Text Alignment (t-alignment)
 //
-// Experimental: Adds new naming convention
+// Experimental: Adds new naming convention {{isHelper}}
 //
 // .t-align-left - Left aligned
 // .t-align-center - Center aligned
@@ -74,7 +74,7 @@
 
 // Text line-height (t-space-type)
 //
-// Experimental: New utility to help eliminate repitition.
+// Experimental: New utility to help eliminate repitition. {{isHelper}}
 //
 // t-space-nospace - Tight leading | line-height: 1
 // t-space-heading-s - More spaced out | line-height: 1.25

--- a/assets/scss/5-typography/_typography-v2.scss
+++ b/assets/scss/5-typography/_typography-v2.scss
@@ -348,7 +348,7 @@ $line-height-type: (
 
 // Word break (t-wrap)
 //
-// Helper classes for handling how words are allowed to wrap and break.
+// Helper classes for handling how words are allowed to wrap and break. {{isHelper}}
 // 
 // .t-wrap-break - Allow a word to wrap to the next line mid-word
 //

--- a/assets/scss/6-components/card/card.html
+++ b/assets/scss/6-components/card/card.html
@@ -230,109 +230,38 @@
 <div class="ds-breathe-vert">
   <h3>HTML Variation 4</h3>
   <p>
-    Overlay; As seen in podcasts. This includes a <code>.c-card__bottom-stick</code>, which is a hack to get the last element of the card to align to the bottom. This card is set as a <code>disply: flex; flex-direction: column</code>. This means its other flex siblings will all be the same height. The player at the bottom is <code>position: aboslute;</code> so that no matter what, it'll always appear at the bottom visually. We shamefully add an inline style of the static height since that can be adjusted in the embed of the player.
+    Overlay; As seen in podcasts.
   </p>
 </div>
-<div class="c-card grid grid_vertical c-card__stick-parent" style="padding-bottom: 105px;">
-  <a href="#" class="l-display-block">
-    <img
-      class="l-display-block l-width-full"
-      src="https://static.feedpress.it/logo/trib-brief-podcast-5ad61ddc8230d.jpg"
-    />
+<article class="grid_row grid_wrap--m c-card c-card__stick-parent grid_separator--xxxl">
+  <div class="col_7 c-card__col">
+  <a href="/podcast/the-brief/" class="l-display-block">
+  <picture class="has-text-gray-dark">
+  <source srcset="https://www.texastribune.org/static/about/images/podcasts/brief-2x.aca85d2bdd95.png 2x, https://www.texastribune.org/static/about/images/podcasts/brief.c78e04c0fe4f.png">
+  <img alt="The Brief podcast" class="l-display-block l-width-full" src="https://www.texastribune.org/static/about/images/podcasts/brief.c78e04c0fe4f.png">
+  </picture>
   </a>
-  <div class="c-card__tag l-display-ib has-bg-black-off t-smallcaps t-center">
-    <div class="t-uppercase has-text-yellow t-size-xs">Daily</div>
-    <div class="t-size-xs has-text-white t-space-nospace">M - F</div>
   </div>
-  <div class="grid grid_separator has-bg-white-off t-size-xs l-align-justify">
-    <div class="grid_row">
-      <a class="col_inline c-button c-button--s has-text-hover-gray-dark has-text-gray has-bg-white-off" href="#"
-        >iTunes</a
-      >
-      <a class="col_inline c-button c-button--s has-text-hover-gray-dark has-text-gray has-bg-white-off" href="#"
-        >Google Play</a
-      >
-      <a class="col_inline c-button c-button--s has-text-hover-gray-dark has-text-gray has-bg-white-off" href="#"
-        >Amazon</a
-      >
-      <a class="col_inline c-button c-button--s has-text-hover-gray-dark has-text-gray has-bg-white-off" href="#">RSS</a>
-    </div>
-  </div>
-  <header class="t-prose grid_separator">
-    <p>
-      Get a quick take on the latest Texas politics and policy news via your
-      favorite podcast app.
-    </p>
-  </header>
-  <div class="c-card__bottom-stick">
-    <span class="t-smallcaps">Listen to the latest episode</span>
-    <a class="spreaker-player" href="https://www.spreaker.com/show/texas-tribune-brief"
-        data-resource="show_id=2716012" data-width="100%" data-height="80px" data-theme="light" data-playlist="false"
-        data-playlist-continuous="false" data-autoplay="false" data-live-autoplay="false" data-chapters-image="true"
-        data-episode-image-position="right" data-hide-logo="true" data-hide-likes="true" data-hide-comments="true"
-        data-hide-sharing="false" data-hide-download="false">Listen to "Texas Tribune Brief" on Spreaker.</a>
-    <span class="t-linkstyle t-uppercase l-display-ib"><a class="t-size-xxs grid_row" href="#">View All
-        Episodes&nbsp;<span class="c-icon"><svg aria-hidden="true"><use xlink:href="#long-arrow-right"></use></svg></span>
-        </svg></a>
-    </span>
-  </div>
-</div>
-
-
-
-<!-- Preview desc -->
-
-
-
-<!-- Preview desc -->
-<div class="ds-breathe-vert">
-  <h3>HTML Variation 6</h3>
-  <p>
-    Overlay; As seen in podcasts. Alternate
-  </p>
-</div>
-<!-- Preview desc -->
-<article class="grid_row grid_wrap--l c-card c-card__stick-parent">
-  <div class="col_6">
-    <a href="/{{ podcast.tt_link_path }}" class="l-display-block">
-      <img class="l-display-block l-width-full" src="thumb.png" />
-    </a>
-    <div class="c-card__bottom-stick l-width-full">
-      <div class="grid has-bg-white-off t-size-xs l-align-justify">
-        <div class="grid_row">
-          <a class="col_inline c-button c-button--s has-text-hover-gray-dark has-text-gray has-bg-white-off"
-            href="#">iTunes</a>
-          <a class="col_inline c-button c-button--s has-text-hover-gray-dark has-text-gray has-bg-white-off" href="#">Google
-            Play</a>
-          <a class="col_inline c-button c-button--s has-text-hover-gray-dark has-text-gray has-bg-white-off"
-            href="#">Amazon</a>
-          <a class="col_inline c-button c-button--s has-text-hover-gray-dark has-text-gray has-bg-white-off" href="#">RSS</a>
-        </div>
-      </div>
-    </div>
-  </div>
-  <section class="col_6 c-card__content">
-    <h3 class="t-headline grid_separator--s t-size-xl t-space-nospace">
-      <a href="/{{ podcast.tt_link_path }}">The Brief</a>
+  <section class="col_6 c-card__content c-card__content--grid">
+    <h3 class="t-headline grid_separator--s t-size-l">
+    <a href="/podcast/the-brief/">The Brief</a>
     </h3>
-    <div class="t-uppercase has-text-black-off t-uppercase--extra-wide grid_separator--s t-size-xs"><strong>Daily | M - F</strong></div>
-    <div class="grid_separator--l t-prose t-size-s">
-      <p class="l-display-inline">
-        Get a quick take on the latest Texas politics and policy news via your favorite podcast app. Also available on Amazon Echo.
+    <div class="grid_separator--s t-uppercase t-uppercase--extra-wide t-size-xs"><strong>Monday - Friday</strong></div>
+    <div class="grid_separator--s t-prose t-size-b">
+      <p>
+      Start your day with a quick take on the latest Texas politics and policy news.
+      Subscribe on
+      <a href="https://itunes.apple.com/us/podcast/texas-tribune-brief/id1362288303?mt=2" target="_blank" rel="noopener noreferrer">iTunes</a>,
+      <a href="https://play.google.com/music/listen?u=0#/ps/Ihttygx5gjxrz56yjtxa7dmjkka" target="_blank" rel="noopener noreferrer">Google Play</a>,
+      <a href="https://open.spotify.com/show/6rQtjb1tJJHeS3aDzxP9td" target="_blank" rel="noopener noreferrer">Spotify</a>,
+      <a href="https://www.amazon.com/gp/product/B076HVR13S?ie=UTF8&amp;ref-suffix=ss_rw" target="_blank" rel="noopener noreferrer">Amazon Echo</a>, or&nbsp;
+      <a href="https://feeds.texastribune.org/feeds/podcasts/brief/" target="_blank" rel="noopener noreferrer">RSS</a>
       </p>
-      <span class="l-display-ib">
-        <a class="t-size-xs grid_row t-uppercase t-uppercase--extra-wide has-text-teal t-space-nospace"
-          href="/{{ podcast.tt_link_path }}">
-          <strong>View All Episodes&nbsp;</strong><span class="c-icon"><svg aria-hidden="true"><use xlink:href="#long-arrow-right"></use></svg></span></a>
-      </span>
     </div>
     <div class="l-width-full">
-      <div class="t-uppercase t-uppercase--extra-wide has-text-gray t-size-xxs grid_separator--s">Play the latest episode</div>
-      <a class="spreaker-player l-display-block" href="https://www.spreaker.com/show/texas-tribune-brief" data-resource="show_id=2716012"
-        data-width="100%" data-height="80px" data-theme="light" data-playlist="false" data-playlist-continuous="false"
-        data-autoplay="false" data-live-autoplay="false" data-chapters-image="true"data-hide-logo="true" data-hide-likes="true" data-hide-comments="true" data-hide-sharing="false" data-hide-download="false" data-cover="https://keen-elion-84a6fc.netlify.com/spreaker-bg.png">Listen to "Texas Tribune Brief" on Spreaker.</a>
+      <div class="t-uppercase t-uppercase--extra-wide has-text-gray t-size-xxs grid_separator--xs">Play the latest episode</div>
+      <iframe src="https://widget.spreaker.com/player?show_id=2716012&amp;theme=light&amp;playlist=true&amp;playlist-continuous=true&amp;playlist-loop=false&amp;playlist-autoupdate=true&amp;autoplay=false&amp;live-autoplay=false&amp;chapters-image=true&amp;episode_image_position=right&amp;hide-likes=true&amp;hide-comments=false&amp;hide-sharing=false&amp;hide-logo=true&amp;hide-download=true&amp;hide-episode-description=false&amp;hide-playlist-images=false&amp;hide-playlist-descriptions=false&amp;gdpr-consent=undefined" class="spreaker-player l-display-block" id="spreaker-player-160950" width="100%" height="78px" frameborder="0"></iframe>
     </div>
   </section>
 </article>
-
 <script async src="https://widget.spreaker.com/widgets.js"></script>

--- a/assets/scss/7-utilities/_color-helpers.scss
+++ b/assets/scss/7-utilities/_color-helpers.scss
@@ -1,6 +1,6 @@
 // Color helper text (has-text-color)
 //
-// New utility to help eliminate repitition.
+// Set the color of text. {{isHelper}}
 //
 // .has-text-black -  black text color
 // .has-text-black-off - black-off text color
@@ -21,9 +21,9 @@
 // Styleguide 7.0.1
 //
 
-// Color helper text hover (has-text-hover-color)
+// Color helper text-hover (has-text-hover-color) 
 //
-// New utility to help eliminate repitition.
+// Set the color of text on hover. {{isHelper}}
 //
 // .has-text-hover-black -  black text-hover color
 // .has-text-hover-black-off - black-off text-hover color
@@ -44,9 +44,9 @@
 // Styleguide 7.0.2
 //
 
-// Color helper background (has-bg-color)
+// Color helper bg (has-bg-color) 
 //
-// New utility to help eliminate repitition.
+// Set the background-color of an element. {{isHelper}}
 //
 // .has-bg-black -  black background color
 // .has-bg-black-off - black-off background color

--- a/assets/scss/7-utilities/_display.scss
+++ b/assets/scss/7-utilities/_display.scss
@@ -1,8 +1,43 @@
+// Display  (l-display)
+//
+// Experimental: Display helpers {{isHelper}}
+//
+// .l-display-ib - Inline Block
+// .l-display-block - Block
+// .l-display-inline - Inline
+// .l-clearfix - Clears floats
+//
+// Markup: <span class="{{ className }} has-bg-gray-light"><span class="l-float-left">Example</span></span>
+// 
+//
+// Styleguide 7.0.4
+.l-display-ib {
+  display: inline-block;
+}
+
+.l-display-block {
+  display: block;
+}
+
+.l-display-inline {
+  display: inline;
+}
+
+.l-clearfix {
+  &:after {
+    content: "";
+    display: table;
+    clear: both;
+  }
+}
+
+
 // Hidden (is-hidden-<specifier>)
 //
-// Experimental: Contain !important flags to override other display rules.
+// Experimental: Contain !important flags to override other display rules. {{isHelper}}
 //
 // .is-hidden -  Hide always
+// .is-hidden-print -  Hide from print previews
 // .is-hidden-from-bp-xs -  Hide from bp-xs onward
 // .is-hidden-from-bp-s -  Hide from bp-s onward
 // .is-hidden-from-bp-m -  Hide from bp-m onward
@@ -25,6 +60,12 @@
 //
 .is-hidden {
   display: none !important;
+}
+
+.is-hidden-print {
+  @media print {
+    display: none !important;
+  }
 }
 
 @each $bp-name, $bp-value in $mq-breakpoints {

--- a/assets/scss/7-utilities/_display.scss
+++ b/assets/scss/7-utilities/_display.scss
@@ -58,9 +58,11 @@
 //
 // Styleguide 7.0.1
 //
-.is-hidden {
+.is-hidden,
+.hidden {
   display: none !important;
 }
+// ^ including a duplicate class of .hidden right now since it's so littered throughout the code base.
 
 .is-hidden-print {
   @media print {

--- a/assets/scss/7-utilities/_layout-v2.scss
+++ b/assets/scss/7-utilities/_layout-v2.scss
@@ -42,73 +42,9 @@
   }
 }
 
-
-// Display  (l-display)
-//
-// Experimental: Display helpers
-//
-// .l-display-ib - Inline Block
-// .l-display-block - Block
-// .l-display-inline - Inline
-// .l-clearfix - Clears floats
-//
-// Markup: <span class="{{ className }} has-bg-gray-light"><span class="l-float-left">Example</span></span>
-// 
-//
-// Styleguide 7.0.4
-.l-display-ib {
-  display: inline-block;
-}
-
-.l-display-block {
-  display: block;
-}
-
-.l-display-inline {
-  display: inline;
-}
-
-.l-clearfix {
-  &:after {
-    content: "";
-    display: table;
-    clear: both;
-  }
-}
-
-
-// Float  (l-float)
-//
-// Experimental: Opinionated floating
-//
-// .l-float--left - Float left
-// .l-float--right  - Float right
-//
-// Markup: <span class="l-display-block l-clearfix has-bg-gray-light"><span class="l-float {{ className }}">Example</span></span>
-// 
-//
-// Styleguide 7.0.4
-.l-float {
-  width: 50%;
-
-  @include mq($until: bp-s) {
-    width: 100%;
-  }
-
-  &--left {
-    float: left;
-    margin: 0 $size-s $size-s 0;
-  }
-
-  &--right {
-    float: right;
-    margin: 0 0 $size-s $size-s;
-  }
-}
-
 // Align (l-align)
 //
-// Experimental: Mostly used for centering and some assume a flex parent.
+// Experimental: Mostly used for centering and some assume a flex parent. {{isHelper}}
 //
 // l-align-center-x - Margin auto FTW
 // l-align-center-y - The ol' vertical transform trick
@@ -148,45 +84,14 @@
 }
 
 
-// Hidden (l-hidden)
-//
-// Experimental: Hides elements for specified experiences.
-//
-// .l-hidden-sr  - Hidden from screen readers
-// .l-hidden-print  - Hidden from printed output
-//
-// Markup: <span style="height: 50px; width: 50px; position: relative" class="has-bg-gray-light"><span class="{{ className }}">Example</span></span>
-// 
-//
-// Styleguide 7.0.4
-.hidden,
-.l-hidden {
-  display: none !important;
-}
-
-.l-hidden-sr {
-  position: absolute;
-  left: -10000px;
-  top: auto;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-}
-
-.l-hidden-print {
-  @media print {
-    display: none !important;
-  }
-}
-
 // Full width (l-width)
 //
-// Experimental: Stretches element to 100% or at most 100% of its natural width
+// Experimental: Stretches element to 100% or at most 100% of its natural width {{isHelper}}
 //
 // .l-width-full - Width is 100% of parent
 // .l-width-max - Max width is 100% of parent
 //
-// Markup: <div style="width: 300px;" class="has-bg-gray-light"><img class="{{ className }}" src="https://picsum.photos/250?random"/></div>
+// Markup: <div class="has-bg-gray-light"><img class="{{ className }}" src="https://picsum.photos/250?random"/></div>
 // 
 //
 // Styleguide 7.0.5

--- a/assets/scss/7-utilities/_layout.scss
+++ b/assets/scss/7-utilities/_layout.scss
@@ -64,7 +64,7 @@
 
 // Self Center
 //
-// Apply to an item with a flex parent
+// Deprecated: Apply to an item with a flex parent
 //
 // Styleguide 7.0.4
 .l-self-center {

--- a/assets/scss/7-utilities/_spacing.scss
+++ b/assets/scss/7-utilities/_spacing.scss
@@ -1,6 +1,6 @@
 // Margin helpers (has-<size>-btm-marg)
 //
-// Experimental: Bottom margin only. Opt for these instead of adding margin-bottom to a new class.
+// Experimental: Bottom margin only. Opt for these instead of adding margin-bottom to a new class. {{isHelper}}
 //
 // .has-xxxl-btm-marg -  Margin bottom with $size-xxxl
 // .has-giant-btm-marg -  Margin bottom with $size-giant
@@ -27,7 +27,7 @@
 
 // Padding helpers (has-padding)
 //
-// Experimental: Not all sizes are accounted for. Often, specific padding rules should go on a component.
+// Experimental: Not all sizes are accounted for. Often, specific padding rules should go on a component. {{isHelper}}
 //
 // .has-padding -  All-around padding with $size-b
 // .has-xs-padding -  All-around padding with $size-xs

--- a/docs/build/docs.js
+++ b/docs/build/docs.js
@@ -84,9 +84,7 @@ module.exports = async () => {
   styleDocs.items.map(section => {
     section.list.map(item => {
       if (item.markup.length > 0) {
-        const out = `${previewPathOut}${section.slug}/${
-          item.mainClass
-        }`;
+        const out = `${previewPathOut}${section.slug}/${item.mainClass}`;
         // map preview
         previewArr.push({
           in: previewPathIn,
@@ -94,13 +92,11 @@ module.exports = async () => {
           data: item,
         });
         // map raw preview for components
-        if (section.slug === 'components') {
-          componentArr.push({
-            in: previewPathInRaw,
-            out: `${out}/raw.html`,
-            data: item,
-          });
-        }
+        componentArr.push({
+          in: previewPathInRaw,
+          out: `${out}/raw.html`,
+          data: item,
+        });
       }
       return;
     });

--- a/docs/src/index.html
+++ b/docs/src/index.html
@@ -6,7 +6,7 @@
   <meta charset="UTF-8" />
   <meta content="width=device-width, initial-scale=1.0" name="viewport" />
   <meta content="ie=edge" http-equiv="X-UA-Compatible" />
-  <title>Document</title>
+  <title>CSS + HTML Guide for The Texas Tribune</title>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.2/css/bulma.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="css/all-legacy.css" />
   <link rel="stylesheet" href="css/all.css" />
@@ -34,7 +34,7 @@
       <div class="tile is-parent is-vertical is-3">
         <aside class="menu ds-stick-it">
           <div class="box buttons has-text-centered">
-              <button class="button is-primary is-fullwidth" id="hideLegacy"><span class="ds-version-tag">Hide</span><span class="ds-version-tag--show">Show</span>&nbsp;Legacy</button>
+              <button class="button is-primary is-fullwidth" id="showLegacy"><span class="ds-version-toggle">Show</span><span>Hide</span>&nbsp;Legacy</button>
             </div>
           <p class="menu-label">
             Sections

--- a/docs/src/js/ds.js
+++ b/docs/src/js/ds.js
@@ -1,35 +1,5 @@
-// Add simple dropdown for Bulma dropdown component
-document.addEventListener('DOMContentLoaded', function() {
-  // Dropdowns
-  var $dropdowns = getAll('.dropdown:not(.is-hoverable)');
-  if ($dropdowns.length > 0) {
-    $dropdowns.forEach(function($el) {
-      $el.addEventListener('click', function(event) {
-        event.stopPropagation();
-        $el.classList.toggle('is-active');
-      });
-    });
-  }
-  function closeDropdowns() {
-    $dropdowns.forEach(function($el) {
-      $el.classList.remove('is-active');
-    });
-  }
-  // Close dropdowns if ESC pressed
-  document.addEventListener('keydown', function(event) {
-    var e = event || window.event;
-    if (e.keyCode === 27) {
-      closeDropdowns();
-    }
-  });
-  // Functions
-  function getAll(selector) {
-    return Array.prototype.slice.call(document.querySelectorAll(selector), 0);
-  }
-});
-
-var hideLegacy = document.querySelector('#hideLegacy');
-hideLegacy.addEventListener('click', function() {
-  document.body.classList.toggle('js-ds-hide-legacy');
+var showLegacy = document.querySelector('#showLegacy');
+showLegacy.addEventListener('click', function() {
+  document.body.classList.toggle('js-ds-show-legacy');
   this.classList.toggle('is-active');
 });

--- a/docs/src/macros/snippet.html
+++ b/docs/src/macros/snippet.html
@@ -30,19 +30,10 @@
             {% endif %}
         {% endif %}
         {% if codeSnippet %}
-            <div class="dropdown is-block">
-                <div class="dropdown-trigger">
-                    <button aria-controls="dropdown-menu" aria-haspopup="true" class="button">
-                        HTML Example
-                    </button>
-                </div>
-                <div class="dropdown-menu ds-code-dropdown" id="dropdown-menu" role="menu">
-                    <div class="dropdown-content">
-                        <pre class="has-text-danger has-background-black">{{codeSnippet | safe}}</pre>
-                    </div>
-                </div>
-            </div>
-            
+            <details>
+                <summary class="button">HTML Example</summary>
+                <pre class="has-text-danger has-background-black">{{codeSnippet | safe}}</pre>
+            </details>
         {% endif %}
     </div>
 </div>

--- a/docs/src/page.html
+++ b/docs/src/page.html
@@ -130,9 +130,11 @@
             </div>
             {% if markup %}
             <div class="columns is-multiline">
-              <div class="column is-full">
-                {{ snippet(item.header, markup, '', isFile, description, codeSnippet, item.mainClass) }}
-              </div>
+              {% if not item.isHelper %}
+                <div class="column is-full">
+                  {{ snippet(item.header, markup, '', isFile, description, codeSnippet, item.mainClass) }}
+                </div>
+              {% endif %}
               {% if (item.modifiers|length) and ( item.groupName === 'Typography' or item.groupName === 'Utility') %}
                 <div class="column is-full">
                   {{ snippetTable(item.modifiers) }}

--- a/docs/src/page.html
+++ b/docs/src/page.html
@@ -10,7 +10,7 @@
   <meta charset="UTF-8" />
   <meta content="width=device-width, initial-scale=1.0" name="viewport" />
   <meta content="ie=edge" http-equiv="X-UA-Compatible" />
-  <title>Document</title>
+  <title>{{name}} | Style Docs for The Texas Tribune.</title>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.2/css/bulma.min.css" rel="stylesheet" />
   <link id="base" rel="stylesheet" href="../../css/all-legacy.css" />
   <link id="base-v2" rel="stylesheet" href="../../css/all.css" />
@@ -28,7 +28,7 @@
           <p class="menu-label">
             <div class="box buttons has-text-centered">
               <a href="../../index.html" class="button is-primary is-outlined is-fullwidth">< Back</a>
-              <button class="button is-primary is-fullwidth" id="hideLegacy"><span class="ds-version-tag">Hide</span><span class="ds-version-tag--show">Show</span>&nbsp;Legacy</button>
+              <button class="button is-primary is-fullwidth" id="showLegacy"><span class="ds-version-toggle">Show</span><span>Hide</span>&nbsp;Legacy</button>
             </div>
           </p>
           <ul class="menu-list ds-menu box has-background-light">
@@ -66,10 +66,10 @@
               <h2 class="title is-{{ item.depth }}">
               {{ item.prettyName }}
               {% if item.experimental %}
-              <span class="tag is-info ds-version-tag">V2</span>
+              <span class="ds-version-tag"><span class="tag is-info">V2</span></span>
               {% endif %}
               {% if item.deprecated %}
-              <span class="tag is-warning ds-version-tag">Legacy</span>
+              <span class="ds-version-tag"><span class="tag is-warning">Legacy</span></span>
               {% endif %}
               </h2>
               <div class="subtitle ds-desc">
@@ -151,30 +151,7 @@
           </div>
           {% endif %}
           {% endfor %}
-          <div class="section ds-spacer">
-            <a class="ds-anchor" id="icons"></a>
-            
-            {% for iconSet in iconSets %}
-              <h3 class="title is-3">{{iconSet.name}}</h3>
-              <div class="columns is-multiline">
-                {% set icons = iconSet.icons %}
-                {% for icon in icons %}
-                  <div class="column is-3">
-                    <div class="card t-center">
-                      <div class="section has-background-light">
-                        <svg class="c-icon c-icon--xxl" aria-hidden="true" focusable="true">
-                          <use xlink:href="#{{icon}}"></use>
-                        </svg>
-                      </div>
-                      <div class="card-content">
-                        <h4 class="subtitle is-4">{{icon}}</h4>
-                      </div>
-                    </div>
-                  </div>
-                {% endfor %}
-              </div>
-            {% endfor %}
-          </section>
+          
         </main>
       </div>
     </div>

--- a/docs/src/preview.html
+++ b/docs/src/preview.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta content="width=device-width, initial-scale=1.0" name="viewport" />
   <meta content="ie=edge" http-equiv="X-UA-Compatible" />
-  <title>Document</title>
+  <title>{{header}} | Style Docs for The Texas Tribune.</title>
   <link id="base" rel="stylesheet" href="../../css/all-legacy.css" />
   <link id="base-v2" rel="stylesheet" href="../../css/all.css" />
   <link id="ds" rel="stylesheet" href="../../css/ds.css" />

--- a/docs/src/scss/ds.scss
+++ b/docs/src/scss/ds.scss
@@ -135,19 +135,24 @@ strong {
   height: 95vh;
 }
 
-.ds-version-tag {
-  &--show {
-    display: none; 
-    
-    .js-ds-hide-legacy & {
-      display: inline;
-    }
-  }
+
+.ds-legacy,
+.ds-version-tag,
+.ds-version-toggle + span {
+  display: none;
 }
 
-.js-ds-hide-legacy .ds-legacy,
-.js-ds-hide-legacy .ds-version-tag {
+.js-ds-show-legacy .ds-legacy,
+.js-ds-show-legacy .ds-version-toggle + span {
+  display: block;
+}
+
+.js-ds-show-legacy .ds-version-toggle {
   display: none;
+}
+
+.js-ds-show-legacy .ds-version-tag {
+  display: inline-block;
 }
 
 // Hide arrow for HTML code snippet

--- a/docs/src/scss/ds.scss
+++ b/docs/src/scss/ds.scss
@@ -149,3 +149,8 @@ strong {
 .js-ds-hide-legacy .ds-version-tag {
   display: none;
 }
+
+// Hide arrow for HTML code snippet
+::-webkit-details-marker {
+  display: none;
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "ansi-colors": "^3.2.4",
+    "autoprefixer": "^9.5.1",
     "browser-sync": "^2.26.3",
     "clean-css": "^4.2.1",
     "fast-glob": "^2.2.6",

--- a/tasks/style-doc.js
+++ b/tasks/style-doc.js
@@ -31,8 +31,12 @@ const processSection = (section, dir) => {
   const isFile = markup.includes('.html');
   const isWideStr = '{{isWide}}';
   const isWide = section.description.includes(isWideStr);
+  const isHelperStr = '{{isHelper}}';
+  const isHelper = section.description.includes(isHelperStr);
   const isTool = header.includes('@');
-  const description = section.description.replace(isWideStr, '');
+  const description = section.description
+    .replace(isWideStr, '')
+    .replace(isHelperStr, '');
   const cleanDesc = stripTags(description);
   const githubLink = `${GITHUB_URL}/${section.source.path}#L${
     section.source.line
@@ -77,6 +81,7 @@ const processSection = (section, dir) => {
     slug,
     isFile,
     isWide,
+    isHelper,
     isTool,
     cleanDesc,
     githubLink,

--- a/yarn.lock
+++ b/yarn.lock
@@ -433,6 +433,18 @@ autoprefixer@^9.0.0:
     postcss "^7.0.14"
     postcss-value-parser "^3.3.1"
 
+autoprefixer@^9.5.1:
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.5.1.tgz#243b1267b67e7e947f28919d786b50d3bb0fb357"
+  integrity sha512-KJSzkStUl3wP0D5sdMlP82Q52JLy5+atf2MHAre48+ckWkXgixmfHyWmA77wFDy6jTHU6mIgXv6hAQ2mf1PjJQ==
+  dependencies:
+    browserslist "^4.5.4"
+    caniuse-lite "^1.0.30000957"
+    normalize-range "^0.1.2"
+    num2fraction "^1.2.2"
+    postcss "^7.0.14"
+    postcss-value-parser "^3.3.1"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -649,6 +661,15 @@ browserslist@^4.4.1:
     electron-to-chromium "^1.3.103"
     node-releases "^1.1.3"
 
+browserslist@^4.5.4:
+  version "4.5.6"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.5.6.tgz#ea42e8581ca2513fa7f371d4dd66da763938163d"
+  integrity sha512-o/hPOtbU9oX507lIqon+UvPYqpx3mHc8cV3QemSBTXwkG8gSQSK6UKvXcE/DcleU3+A59XTUHyCvZ5qGy8xVAg==
+  dependencies:
+    caniuse-lite "^1.0.30000963"
+    electron-to-chromium "^1.3.127"
+    node-releases "^1.1.17"
+
 bs-recipes@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/bs-recipes/-/bs-recipes-1.3.4.tgz#0d2d4d48a718c8c044769fdc4f89592dc8b69585"
@@ -753,6 +774,11 @@ caniuse-lite@^1.0.30000929, caniuse-lite@^1.0.30000932:
   version "1.0.30000935"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000935.tgz#d1b59df00b46f4921bb84a8a34c1d172b346df59"
   integrity sha512-1Y2uJ5y56qDt3jsDTdBHL1OqiImzjoQcBG6Yl3Qizq8mcc2SgCFpi+ZwLLqkztYnk9l87IYqRlNBnPSOTbFkXQ==
+
+caniuse-lite@^1.0.30000957, caniuse-lite@^1.0.30000963:
+  version "1.0.30000967"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000967.tgz#a5039577806fccee80a04aaafb2c0890b1ee2f73"
+  integrity sha512-rUBIbap+VJfxTzrM4akJ00lkvVb5/n5v3EGXfWzSH5zT8aJmGzjA8HWhJ4U6kCpzxozUSnB+yvAYDRPY6mRpgQ==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1369,6 +1395,11 @@ electron-to-chromium@^1.3.103:
   version "1.3.113"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz#b1ccf619df7295aea17bc6951dc689632629e4a9"
   integrity sha512-De+lPAxEcpxvqPTyZAXELNpRZXABRxf+uL/rSykstQhzj/B0l1150G/ExIIxKc16lI89Hgz81J0BHAcbTqK49g==
+
+electron-to-chromium@^1.3.127:
+  version "1.3.133"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.133.tgz#c47639c19b91feee3e22fad69f5556142007008c"
+  integrity sha512-lyoC8aoqbbDqsprb6aPdt9n3DpOZZzdz/T4IZKsR0/dkZIxnJVUjjcpOSwA66jPRIOyDAamCTAUqweU05kKNSg==
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -3342,6 +3373,13 @@ node-pre-gyp@^0.10.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
+
+node-releases@^1.1.17:
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.18.tgz#cc98fd75598a324a77188ebddf6650e9cbd8b1d5"
+  integrity sha512-/mnVgm6u/8OwlIsoyRXtTI0RfQcxZoAZbdwyXap0EeWwcOpDDymyCHM2/aR9XKmHXrvizHoPAOs0pcbiJ6RUaA==
+  dependencies:
+    semver "^5.3.0"
 
 node-releases@^1.1.3:
   version "1.1.7"


### PR DESCRIPTION
- Adds linting
- Introduces helper class `{{isHelper}}` to hide previews for helper/non BEM naming conventions
- And just some general cleanup...
     - Creates raw previews for non components
     - Removes float classes
     - Removes old podcast card prototypes
     - Adds better title text
     - Defaults the view to hide legacy styles
     - Moves display classes into _display
