### PR TITLE
A few small things

### DIFF
--- a/assets/scss/6-components/full-page-loader/_full-page-loader.scss
+++ b/assets/scss/6-components/full-page-loader/_full-page-loader.scss
@@ -2,11 +2,11 @@ $loader-bar-height: 10px;
 
 // Full-page loader (c-full-page-loader)
 //
-// For putting entire width and height of page in a loading state. Inspired by: https://codepen.io/brunjo/pen/XJmbNz
+// For putting a translucent overlay over the entire page. Can contain nested items (including .c-loading), probably with absolute positioning.
 //
 // Styleguide 6.1.1
 .c-full-page-loader {
-  background-color: rgba($color-white-pure, .95);
+  background-color: rgba(247, 247, 247, 0.9);
   height: 100%;
   left: 0;
   position: fixed;
@@ -15,37 +15,4 @@ $loader-bar-height: 10px;
   // normally this is terrible, but we can say with
   // confidence this component should always be on top
   z-index: 9999;
-
-  &__bar {
-    background-color: $color-white-off;
-    height: $loader-bar-height;
-    overflow: hidden;
-    position: relative;
-    width: 100%;
-    
-    &:before {
-      animation: loading-bar 2s linear infinite;
-      background-color: $color-yellow-tribune;
-      content: '';
-      display: block;
-      height: $loader-bar-height;
-      left: -200px;
-      position: absolute;
-      width: 200px;
-    }
-  }
-}
-
-@keyframes loading-bar {
-  from { left: -200px; width: 30%; }
-  
-  50% { width: 30%; }
-  
-  70% { width: 70%; }
-  
-  80% { left: 50%; }
-  
-  95% { left: 120%; }
-  
-  to { left: 100%; }
 }

--- a/assets/scss/6-components/info-list/_info-list.scss
+++ b/assets/scss/6-components/info-list/_info-list.scss
@@ -8,6 +8,7 @@
 .c-info-list {
   display: flex;
   flex-wrap: wrap;
+  list-style: none;
 
   &__item {
     flex: 1 1 auto;

--- a/assets/scss/6-components/table/table.html
+++ b/assets/scss/6-components/table/table.html
@@ -1,9 +1,9 @@
 <table class="c-table {{ className }} l-width-full">
   <thead>
     <tr>
-      <th><strong>A</strong></th>
-      <th><strong>B</strong></th>
-      <th><strong>C</strong></th>
+      <th class="t-align-left"><strong>A</strong></th>
+      <th class="t-align-left"><strong>B</strong></th>
+      <th class="t-align-left"><strong>C</strong></th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
+ Adds missing `list-style:none;` to `.c-info-list`
+ Forces `th` elements to align left
+ Revamps `.c-full-page-loader` to make it a simple translucent overlay that can in turn contain other stuff, including our `.c-loading` component