### PR TITLE
Reconfigure styles.js to add file revving to outputted CSS + a map of those names

### DIFF
--- a/docs/build/build.js
+++ b/docs/build/build.js
@@ -1,3 +1,6 @@
+// utility
+const fs = require('fs-extra');
+
 // lib
 const stylesRunner = require('../../tasks/styles');
 const iconsRunner = require('../../tasks/icons');
@@ -6,14 +9,23 @@ const copyRunner = require('../../tasks/copy');
 // custom to this build
 const docsRunner = require('./docs.js');
 
-const { mappedStyles, mappedIcons, mappedCopies } = require('./paths.js');
+const {
+  mappedStyles,
+  mappedIcons,
+  mappedCopies,
+  mappedStylesManifest,
+  buildDir,
+} = require('./paths.js');
 
 async function build() {
+  // empty dist
+  await fs.emptyDir(buildDir);
+
   // compile and move files
-  await stylesRunner(mappedStyles);
+  await stylesRunner(mappedStyles, mappedStylesManifest);
   await iconsRunner(mappedIcons);
   await copyRunner(mappedCopies);
-  
+
   // build doc data and template
   await docsRunner();
 }

--- a/docs/build/build.js
+++ b/docs/build/build.js
@@ -19,7 +19,7 @@ const {
 
 async function build() {
   // empty dist
-  await fs.emptyDir(buildDir);
+  // await fs.emptyDir(buildDir);
 
   // compile and move files
   await stylesRunner(mappedStyles, mappedStylesManifest);

--- a/docs/build/paths.js
+++ b/docs/build/paths.js
@@ -1,28 +1,33 @@
+const buildDir = './docs/dist/';
+
 const mappedStyles = [
   {
     in: './docs/src/scss/ds.scss',
-    out: './docs/dist/css/ds.css',
+    out: `${buildDir}css/ds.css`,
   },
   {
     in: './assets/scss/all.scss',
-    out: './docs/dist/css/all.css',
+    out: `${buildDir}css/all.css`,
   },
   {
     in: './assets/scss/all-legacy.scss',
-    out: './docs/dist/css/all-legacy.css',
+    out: `${buildDir}css/all-legacy.css`,
   },
 ];
+
+// cache busting map
+const mappedStylesManifest = `${buildDir}css/styles.json`;
 
 const docsStyles = './assets/scss/';
 
 const mappedIcons = [
   {
     in: './assets/icons/amp/',
-    out: './docs/dist/sprites/amp.html',
+    out: `${buildDir}sprites/amp.html`,
   },
   {
     in: './assets/icons/base/',
-    out: './docs/dist/sprites/base.html',
+    out: `${buildDir}sprites/base.html`,
   },
 ];
 
@@ -31,18 +36,20 @@ const docsIcons = ['./assets/icons/'];
 const mappedCopies = [
   {
     in: './docs/src/img',
-    out: './docs/dist/img',
+    out: `${buildDir}img`,
   },
   {
     in: './docs/src/js',
-    out: './docs/dist/js',
+    out: `${buildDir}js`,
   },
 ];
 
 module.exports = {
   mappedStyles,
+  mappedStylesManifest,
   docsStyles,
   mappedIcons,
   docsIcons,
   mappedCopies,
+  buildDir,
 };

--- a/docs/build/watch.js
+++ b/docs/build/watch.js
@@ -13,7 +13,11 @@ const {
 } = require('../../tasks/utils');
 
 const docsRunner = require('./docs.js');
-const { mappedStyles, mappedCopies } = require('./paths.js');
+const {
+  mappedStyles,
+  mappedCopies,
+  mappedStylesManifest,
+} = require('./paths.js');
 
 module.exports = async () => {
   // create the browser-sync client
@@ -77,10 +81,9 @@ module.exports = async () => {
         }
       };
 
-
       const compile = async () => {
         try {
-          await stylesRunner(mappedStyles);
+          await stylesRunner(mappedStyles, mappedStylesManifest);
           stylesError = null;
         } catch (err) {
           stylesError = err;

--- a/docs/src/index.html
+++ b/docs/src/index.html
@@ -8,9 +8,9 @@
   <meta content="ie=edge" http-equiv="X-UA-Compatible" />
   <title>CSS + HTML Guide for The Texas Tribune</title>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.2/css/bulma.min.css" rel="stylesheet" />
-  <link rel="stylesheet" href="css/all-legacy.css" />
-  <link rel="stylesheet" href="css/all.css" />
-  <link id="ds" rel="stylesheet" href="css/ds.css" />
+  <link rel="stylesheet" href="css/{{bundles['all-legacy']}}" />
+  <link rel="stylesheet" href="css/{{bundles['all']}}" />
+  <link rel="stylesheet" href="css/{{bundles['ds']}}" />
 </head>
 
 <body class="fonts-loaded">

--- a/docs/src/page.html
+++ b/docs/src/page.html
@@ -12,9 +12,9 @@
   <meta content="ie=edge" http-equiv="X-UA-Compatible" />
   <title>{{name}} | Style Docs for The Texas Tribune.</title>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.2/css/bulma.min.css" rel="stylesheet" />
-  <link id="base" rel="stylesheet" href="../../css/all-legacy.css" />
-  <link id="base-v2" rel="stylesheet" href="../../css/all.css" />
-  <link id="ds" rel="stylesheet" href="../../css/ds.css" />
+  <link rel="stylesheet" href="../../css/{{bundles['all-legacy']}}" />
+  <link rel="stylesheet" href="../../css/{{bundles['all']}}" />
+  <link rel="stylesheet" href="../../css/{{bundles['ds']}}" />
 </head>
 
 <body class="fonts-loaded">

--- a/docs/src/preview.html
+++ b/docs/src/preview.html
@@ -5,9 +5,9 @@
   <meta content="width=device-width, initial-scale=1.0" name="viewport" />
   <meta content="ie=edge" http-equiv="X-UA-Compatible" />
   <title>{{header}} | Style Docs for The Texas Tribune.</title>
-  <link id="base" rel="stylesheet" href="../../css/all-legacy.css" />
-  <link id="base-v2" rel="stylesheet" href="../../css/all.css" />
-  <link id="ds" rel="stylesheet" href="../../css/ds.css" />
+  <link rel="stylesheet" href="../../css/{{bundles['all-legacy']}}" />
+  <link rel="stylesheet" href="../../css/{{bundles['all']}}" />
+  <link rel="stylesheet" href="../../css/{{bundles['ds']}}" />
 </head>
 <body>
   <div style="display: none">

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -62,6 +62,7 @@ const processSass = async dirMap => {
   if (isProductionEnv) {
     const cssCleaner = new CleanCSS({
       returnPromise: true,
+      level: 2,
     });
     const { styles: minified } = await cssCleaner.minify(css);
     css = minified;

--- a/tasks/utils.js
+++ b/tasks/utils.js
@@ -1,5 +1,5 @@
 // internal
-const fs = require('fs');
+const fs = require('fs-extra');
 // native
 const path = require('path');
 
@@ -274,6 +274,20 @@ const logErrorMessage = err => {
   console.log(`${message || err}\n\n`);
 };
 
+const bustCache = file => {
+  const ext = path.extname(file);
+  const baseName = path.basename(file, ext);
+  const bustedName = `${baseName}.${Date.now()}${ext}`;
+  const bustedLocation = `${path.dirname(file)}/${bustedName}`;
+  return {
+    baseName,
+    bustedName,
+    bustedLocation,
+  };
+};
+
+const getBundles = async mapLocation => await fs.readJson(mapLocation);
+
 module.exports = {
   clearConsole,
   logMessage,
@@ -288,4 +302,6 @@ module.exports = {
   parallel,
   series,
   printInstructions,
+  bustCache,
+  getBundles,
 };


### PR DESCRIPTION
High level overview of what happens to SCSS on build now:

1. All the same compiling as before (only with level 2 CSS cleaning 😱 )
2. Instead of `mystyles.css`, a name of `mystyles + Date.now() + .css` will output into the specified out directory
3. In order to use that file, we need an automatic output of the raw name and revved name. For that, we now pass a map location (`mappedStylesManifest`) in `styles.js` to specify where the following map should output:
```json
{
  "ds": "ds.1557765106956.css",
  "all": "all.1557765106961.css",
  "all-legacy": "all-legacy.1557765107018.css"
}
```
4. We only update the date string if the file is different from before.