### PR TITLE
Better .c-info-list

### DIFF
--- a/assets/scss/6-components/info-list/_info-list.scss
+++ b/assets/scss/6-components/info-list/_info-list.scss
@@ -6,15 +6,8 @@
 //
 // Styleguide 6.1.3
 .c-info-list {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: $size-xl;
   list-style: none;
-
-  &__item {
-    flex: 1 1 auto;
-
-    @include mq($until: bp-l) {
-      flex: 1 1 100%;
-    }
-  }
 }

--- a/assets/scss/6-components/info-list/_info-list.scss
+++ b/assets/scss/6-components/info-list/_info-list.scss
@@ -10,4 +10,8 @@
   grid-template-columns: repeat(3, 1fr);
   gap: $size-xl;
   list-style: none;
+
+  @include mq($until: bp-s) {
+    grid-template-columns: 1fr;
+  }
 }

--- a/assets/scss/6-components/info-list/info-list.html
+++ b/assets/scss/6-components/info-list/info-list.html
@@ -1,14 +1,14 @@
-<ul class="c-info-list t-sans">
-  <li class="c-info-list__item has-xs-padding">
+<ul class="c-info-list">
+  <li>
     <!-- doesn't have to be h3; use what's semantic -->
     <h3 class="t-size-b"><strong>Name</strong></h3>
     <p>Andrew Gibson</p>
   </li>
-  <li class="c-info-list__item has-xs-padding">
+  <li>
     <h3 class="t-size-b"><strong>Email</strong></h3>
     <p>agibson@texastribune.org</p>
   </li>
-  <li class="c-info-list__item has-xs-padding">
+  <li>
     <h3 class="t-size-b"><strong>Zip code</strong></h3>
     <p>78701</p>
   </li>


### PR DESCRIPTION
Use grid instead of flexbox to better accommodate multiple rows of items.