### PR TITLE
Improve .c-navbar styles

### DIFF
--- a/assets/scss/6-components/navbar/_navbar.scss
+++ b/assets/scss/6-components/navbar/_navbar.scss
@@ -7,34 +7,46 @@
 //
 // Styleguide 6.1.3
 .c-navbar {
-  background-color: $color-black-off;
   display: flex;
-  padding: 0 $size-s;
+  padding: 0 $size-b;
 
   @include mq($until: bp-l) {
     flex-wrap: wrap;
+  }
+
+  &--light {
+    background-color: $color-white-pure;
+    border-bottom: 1px solid $color-white-off;
+
+    .c-icon {
+      color: $color-black-off;
+    }
+  }
+
+  &--dark {
+    background-color: $color-black-off;
+
+    .c-icon {
+      color: $color-yellow-tribune;
+    }
   }
 
   &__top {
     flex: 0 1 100%;
     display: flex;
     height: 45px;
-    margin-left: auto;
-    margin-right: auto;
+    justify-content: space-between;
+    max-width: 100rem;
     position: relative;
 
-    &--home {
-      max-width: 1080px;
-    }
-
-    &--standard {
-      justify-content: space-between;
-      max-width: 1600px;
+    // move to texastribune repo
+    .c-navbar--home & {
+      justify-content: normal;
+      max-width: 67.5rem; // maybe use l-container class
     }
   }
 
   &__logo {
-    align-self: center;
     flex: 0 1 210px;
 
     img {
@@ -45,7 +57,8 @@
   &__content {
     display: flex;
 
-    &--home {
+    // move to texastribune repo
+    .c-navbar--home & {
       flex: 0 1 100%;
       justify-content: space-between;
     }
@@ -70,36 +83,28 @@
 
   &__clickable {
     align-items: center;
-    background-color: $color-black-off;
     border: none;
-    color: $color-gray-light;
+    cursor: pointer;
     display: flex;
-    font-size: $size-xxs;
-    font-weight: 700;
-    letter-spacing: 0.07rem;
     padding: 0;
     position: relative;
     text-decoration: none;
-    text-transform: uppercase;
     transition: all 0.15s;
 
-    &:after {
-      content: '';
-      height: 3px;
-      left: 0;
-      position: absolute;
-      top: 100%;
-      width: 100%;
-      transition: background-color 0.15s;
-      @include mq($from: bp-l) {
-        top: auto;
-        bottom: 0;
-      }
+    .c-navbar--light & {
+      background-color: $color-white-pure;
+      color: $color-black-off;
     }
 
-    &:hover,
-    &:active {
-      color: $color-white-pure;
+    .c-navbar--dark & {
+      background-color: $color-black-off;
+      color: $color-gray-light;
+
+      &:hover,
+      &:active,
+      &.is-active {
+        color: $color-white-pure;
+      }
     }
 
     &--animated {
@@ -112,15 +117,50 @@
       }
     }
 
-    &--current {
-      color: $color-white-pure;
-
+    &.is-active {
       &:after {
         background-color: $color-yellow-tribune;
       }
     }
+
+    &:after {
+      content: '';
+      height: 3px;
+      left: 0;
+      position: absolute;
+      top: 100%;
+      width: 100%;
+      transition: background-color 0.15s;
+
+      @include mq($from: bp-l) {
+        top: auto;
+        bottom: 0;
+      }
+    }
   }
 
+  &__dropdown {
+    display: flex;
+    flex: 1 1 100%;
+    flex-wrap: wrap;
+    padding: $size-b/2 0 0 0;
+  }
+
+  &__dropdown-items {
+    display: flex;
+    flex-wrap: wrap;
+    list-style: none;
+  }
+
+  &__dropdown-item {
+    margin-right: $size-m;
+    margin-bottom: $size-m;
+  }
+
+  //
+  // UNTOUCHED CSS STARTS HERE
+  // move all to texastribune repo
+  //
   &__search {
     background-color: $color-black-off;
     bottom: 1px;
@@ -163,31 +203,9 @@
     margin-right: $size-b;
   }
 
-  &__dropdown {
-    display: flex;
-    flex: 1 1 100%;
-    flex-wrap: wrap;
-    padding: $size-b/2 0 0 0;
-  }
-
-  &__dropdown-items {
-    display: flex;
-    flex-wrap: wrap;
-    list-style: none;
-  }
-
-  &__dropdown-item {
-    margin-right: $size-m;
-    margin-bottom: $size-m;
-  }
-
-  &__dropdown-search {
-    flex: 1 1 100%;
-  }
-
   &__greeting {
     display: flex;
     list-style: none;
   }
-  
 }
+

--- a/assets/scss/6-components/navbar/_navbar.scss
+++ b/assets/scss/6-components/navbar/_navbar.scss
@@ -1,6 +1,6 @@
 // Navbar (c-navbar)
 //
-// Main navigation bar {{isWide}}
+// Main navigation bar. To use a white background, change .c-navbar--dark to .c-navbar--light and update the Tribune logo to one with black text. {{isWide}}
 //
 //
 // Markup: 6-components/navbar/navbar.html
@@ -42,7 +42,7 @@
     // move to texastribune repo
     .c-navbar--home & {
       justify-content: normal;
-      max-width: 67.5rem; // maybe use l-container class
+      max-width: 67.5rem;
     }
   }
 

--- a/assets/scss/6-components/navbar/navbar.html
+++ b/assets/scss/6-components/navbar/navbar.html
@@ -1,226 +1,89 @@
-<nav class="c-navbar">
-  <div class="c-navbar__top c-navbar__top--home">
-    <div class="c-navbar__content c-navbar__content--home">
-      <ul class="c-navbar__items hide_from--l">
+<nav class="c-navbar c-navbar--dark">
+  <div class="c-navbar__top l-align-center-x">
+    <a href="https://www.texastribune.org" class="c-navbar__logo l-align-center-self">
+      <img alt="The Texas Tribune" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAxNy4xLjAsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+DQo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IiB2aWV3Qm94PSIwIDAgNTAwIDU1LjA3NCIgZW5hYmxlLWJhY2tncm91bmQ9Im5ldyAwIDAgNTAwIDU1LjA3NCIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+DQoJPGc+DQoJCTxnPg0KCQkJPHBhdGggZmlsbD0iI0ZGRkZGRiIgZD0iTTcyLjUxMSw4LjczdjM5LjE0NGgtOC43OTlWOC43M2gtOC42NlYwLjk4N2gyNi4wNDlWOC43M0g3Mi41MTF6Ii8+DQoJCQk8cGF0aCBmaWxsPSIjRkZGRkZGIiBkPSJNMTAyLjUxLDQ3Ljg3NFYyOC42NTVoLTkuNzg2djE5LjIxOWgtOC43MjlWMC45ODdoOC43Mjl2MTkuODU1aDkuNzg2VjAuOTg3aDguODAxdjQ2Ljg4N0gxMDIuNTF6Ii8+DQoJCQk8cGF0aCBmaWxsPSIjRkZGRkZGIiBkPSJNMTE2Ljc2Miw0Ny44NzRWMC45ODdoMjIuMzg3djcuNTMySDEyNS40OXYxMS42MTdoOS40MzR2Ni45aC05LjQzNHYxMy4wMjNoMTMuNjU5djcuODE1SDExNi43NjJ6Ii8+DQoJCQk8cGF0aCBmaWxsPSIjRkZGRkZGIiBkPSJNMTY5LjU2LDguNzN2MzkuMTQ0aC04LjgwMVY4LjczaC04LjY2VjAuOTg3aDI2LjA0OVY4LjczSDE2OS41NnoiLz4NCgkJCTxwYXRoIGZpbGw9IiNGRkZGRkYiIGQ9Ik0xODEuOTE4LDQ3Ljg3NFYwLjk4N2gyMi4zODl2Ny41MzJoLTEzLjY1OHYxMS42MTdoOS40MzN2Ni45aC05LjQzM3YxMy4wMjNoMTMuNjU4djcuODE1SDE4MS45MTh6Ii8+DQoJCQk8cGF0aCBmaWxsPSIjRkZGRkZGIiBkPSJNMjI2Ljk4MSw0Ny44NzRsLTUuNDkyLTE2LjE5MWwtNS45ODMsMTYuMTkxaC04LjUxOWw5LjY0NS0yMy42NTZMMjA3LjU1LDAuOTg3aDkuMTUzbDUuMTM4LDE2LjE5MQ0KCQkJCWw1LjYzMy0xNi4xOTFoOC41OWwtOS4zNjMsMjIuNTI5bDkuNDMzLDI0LjM1OEgyMjYuOTgxeiIvPg0KCQkJPHBhdGggZmlsbD0iI0ZGRkZGRiIgZD0iTTI1Ny41NTgsNDcuODc0bC0xLjU1LTkuMjIxaC04LjMwN2wtMS42OSw5LjIyMWgtOC4xNjdsOS40MzQtNDYuODg3aDkuNzg2bDkuMzYzLDQ2Ljg4N0gyNTcuNTU4eg0KCQkJCSBNMjUyLjA2NiwxMy42NTlsLTMuMTY5LDE4LjA5NGg1Ljk4NEwyNTIuMDY2LDEzLjY1OXoiLz4NCgkJCTxwYXRoIGZpbGw9IiNGRkZGRkYiIGQ9Ik0yODAuNTc0LDQ4LjkzYy04LjAyNiwwLTEzLjAyNC00Ljc4NS0xMy4wMjQtMTIuMTA5di0zLjIzOGg4LjAyNnYyLjc0NmMwLDMuNDQ5LDEuNjE5LDUuMzUyLDQuNzg4LDUuMzUyDQoJCQkJYzMuMDk4LDAsNC42NDYtMS44MzIsNC42NDYtNC43MThjMC0zLjczMS0yLjM5NC02LjI2NS03LjA0MS05LjcxNWMtNC43ODYtMy40NS05Ljk5Ni04LjA5Ni05Ljk5Ni0xNC42NDINCgkJCQlDMjY3Ljk3Miw1Ljg0NCwyNzIuMzM3LDAsMjgwLjc4NSwwYzcuMzkzLDAsMTIuMzIxLDUuMDcsMTIuMzIxLDEyLjA0djMuMDI3aC03Ljk1NnYtMi44MTdjMC0yLjg4Ni0xLjQ3Ni00Ljk5OC00LjQzNC00Ljk5OA0KCQkJCWMtMi41MzQsMC00LjIyNSwxLjYxOS00LjIyNSw0LjIyNWMwLDMuOTQyLDIuMzIzLDUuOTg0LDcuNTMyLDkuNzg2YzUuNTY0LDQuMTUzLDkuNTA2LDguMzc4LDkuNTA2LDE0LjcxNQ0KCQkJCUMyOTMuNTI4LDQzLjUxLDI4OC4zMTksNDguOTMsMjgwLjU3NCw0OC45M3oiLz4NCgkJCTxwYXRoIGZpbGw9IiNGRkZGRkYiIGQ9Ik0zMjIuNTUyLDguNzN2MzkuMTQ0aC04LjhWOC43M2gtOC42NjFWMC45ODdoMjYuMDUxVjguNzNIMzIyLjU1MnoiLz4NCgkJCTxwYXRoIGZpbGw9IiNGRkZGRkYiIGQ9Ik0zNTYuNDY3LDQ4LjE1N2MtMy40NSwwLTQuNzg4LTIuODE3LTQuNzg4LTYuOXYtOC44YzAtMi4xODItMS4xMjctNC4wMTMtMy41OS00LjAxM2gtNC41NzZ2MTkuNDMxaC04LjczDQoJCQkJVjAuOTg3aDE0LjQzMmM2LjQwNSwwLDEwLjcsMy42NjIsMTAuNywxMC4yMDd2Ni42MmMwLDMuNTE4LTEuNjE5LDYuMTI0LTUuMjc5LDcuMjVjMy42NTksMC45ODcsNS40Miw0LjA4Myw1LjQyLDcuMTExdjguNTkNCgkJCQljMCwyLjE4MywwLjYzMywzLjY1OSwxLjY5MSw0Ljc4NnYyLjYwNkgzNTYuNDY3eiBNMzUxLjM5NywxMS41NDZjMC0yLjExMS0wLjkxNS0zLjM4LTMuMDk3LTMuMzhoLTQuNzg2djEzLjhoNC40MzYNCgkJCQljMi4yNTIsMCwzLjQ0Ny0xLjE5OCwzLjQ0Ny0zLjczMVYxMS41NDZ6Ii8+DQoJCQk8cGF0aCBmaWxsPSIjRkZGRkZGIiBkPSJNMzY2LjkxNSw0Ny44NzRWMC45ODdoOC43MzF2NDYuODg3SDM2Ni45MTV6Ii8+DQoJCQk8cGF0aCBmaWxsPSIjRkZGRkZGIiBkPSJNMzk3LjQ2NSw0Ny44NzRoLTE0Ljc4M1YwLjk4N2gxNC42NDRjNi40MDcsMCwxMC4zNDksMy40NSwxMC4zNDksOS45Mjh2NS4wNjgNCgkJCQljMCw0LjAxMy0xLjU1LDcuMDQyLTUuNTYyLDcuODg0YzQuMjI2LDEuMTI4LDUuNzczLDQuMDE0LDUuNzczLDcuOTU4djYuMTI0QzQwNy44ODYsNDQuNDk2LDQwMy44NzIsNDcuODc0LDM5Ny40NjUsNDcuODc0eg0KCQkJCSBNMzk5LjI5NywxMS41NDZjMC0yLjExMS0wLjkxNi0zLjM4LTMuMDk5LTMuMzhoLTQuNzE2djEyLjg4NWg0LjM2NGMyLjI1NCwwLDMuNDUxLTEuMTk4LDMuNDUxLTMuNjYyVjExLjU0NnogTTM5OS40MzcsMzEuMTkxDQoJCQkJYzAtMi40NjUtMS4xOTYtMy43MzEtMy40NDktMy43MzFoLTQuNTA2djEzLjIzNWg0LjkyOGMyLjE4MywwLDMuMDI3LTEuMTk4LDMuMDI3LTMuMzc5VjMxLjE5MXoiLz4NCgkJCTxwYXRoIGZpbGw9IiNGRkZGRkYiIGQ9Ik00MjYuMjc5LDQ4LjkzYy03LjYwNCwwLTEzLjIzNi00Ljg1Ny0xMy4yMzYtMTEuODk5VjAuOTg3aDguODd2MzYuMDQ1YzAsMi43NDYsMS41NDgsNC4yOTcsNC4zNjYsNC4yOTcNCgkJCQljMi44ODYsMCw0LjQzNC0xLjU1MSw0LjQzNC00LjI5N1YwLjk4N2g4LjUxOHYzNi4wNDVDNDM5LjIzMSw0NC4wNzMsNDMzLjg4MSw0OC45Myw0MjYuMjc5LDQ4LjkzeiIvPg0KCQkJPHBhdGggZmlsbD0iI0ZGRkZGRiIgZD0iTTQ2NC45NjcsNDcuODc0bC05LjA4My0xOS45OTRsLTMuMzA5LTcuNDYydjI3LjQ1NWgtOC4wMjdWMC45ODdoNy41MzVsOC42NTgsMjAuMzQ2bDMuMDk5LDcuNDYzVjAuOTg3DQoJCQkJaDcuODg2djQ2Ljg4N0g0NjQuOTY3eiIvPg0KCQkJPHBhdGggZmlsbD0iI0ZGRkZGRiIgZD0iTTQ3Ny42MTMsNDcuODc0VjAuOTg3SDUwMHY3LjUzMmgtMTMuNjU4djExLjYxN2g5LjQzNHY2LjloLTkuNDM0djEzLjAyM0g1MDB2Ny44MTVINDc3LjYxM3oiLz4NCgkJPC9nPg0KCQk8cGF0aCBmaWxsPSIjRkVCRjEwIiBkPSJNMCwwLjUwOXY1NC41NjVsMTAuOTczLTYuODU5aDM2LjczM1YwLjUwOUgweiBNMzQuMTY1LDM4LjYwOWwtMTAuNDUtNi44NzVsLTEwLjQ0OCw2Ljg3NWwzLjMxLTEyLjA2DQoJCQlsLTkuNzY3LTcuODEybDEyLjQ5My0wLjU4bDQuNDEyLTExLjcwM2w0LjQxMiwxMS43MDNsMTIuNDkzLDAuNThsLTkuNzY3LDcuODEyTDM0LjE2NSwzOC42MDl6Ii8+DQoJPC9nPg0KPC9zdmc+DQo=" />
+    </a>
+    
+    <div class="c-navbar__content">
+      <ul class="c-navbar__items is-hidden-until-bp-l">
+        <li class="c-navbar__item c-navbar__item--space-right">
+          <a href="#" class="is-active c-navbar__item-content c-navbar__clickable c-navbar__clickable--animated t-size-xxs t-uppercase t-uppercase--extra-wide">
+            <strong>Link 1</strong>
+          </a>
+        </li>
+        <li class="c-navbar__item c-navbar__item--space-right">
+          <a href="#"
+            class="c-navbar__item-content c-navbar__clickable c-navbar__clickable--animated t-size-xxs t-uppercase t-uppercase--extra-wide">
+            <strong>Link 2</strong>
+          </a>
+        </li>
+        <li class="c-navbar__item c-navbar__item--space-right">
+          <a href="#"
+            class="c-navbar__item-content c-navbar__clickable c-navbar__clickable--animated t-size-xxs t-uppercase t-uppercase--extra-wide">
+            <strong>Link 3</strong>
+          </a>
+        </li>
         <li class="c-navbar__item">
-          <button
-            id="nav-menu-open"
-            class="c-navbar__item-content c-navbar__text c-navbar__clickable"
-            aria-label="Show menu"
-            ga-on="click"
-            ga-event-category="navigation"
-            ga-event-action="top nav click"
-            ga-event-label="menu-open"
-          >
-          <span class="c-icon"><svg aria-hidden="true"><use xlink:href="#bars"></use></svg></span>&nbsp;Menu</button>
-        </li>
-        <li id="nav-menu-close" class="c-navbar__item hidden">
-          <button
-            class="c-navbar__item-content c-navbar__text c-navbar__clickable"
-            aria-label="Hide menu"
-            ga-on="click"
-            ga-event-category="navigation"
-            ga-event-action="top nav click"
-            ga-event-label="menu-close"
-          >
-          <span class="c-icon"><svg aria-hidden="true"><use xlink:href="#close"></use></svg></span>&nbsp;Close
-          </button>
-        </li>
-      </ul>
-      <ul class="c-navbar__items hide_until--l ">
-        <li class="c-navbar__item c-navbar__item--space-right">
-          <a
-            class="c-navbar__item-content c-navbar__clickable c-navbar__clickable--animated "
-            href="/our-picks/"
-            ga-on="click"
-            ga-event-category="navigation"
-            ga-event-action="top nav click"
-            ga-event-label="our-picks"
-            >Our Picks</a
-          >
-        </li>
-        <li class="c-navbar__item c-navbar__item--space-right">
-          <a
-            class="c-navbar__item-content c-navbar__clickable c-navbar__clickable--animated "
-            href="/series/news-apps-graphics-databases/"
-            ga-on="click"
-            ga-event-category="navigation"
-            ga-event-action="top nav click"
-            ga-event-label="data"
-            >Data</a
-          >
-        </li>
-        <li class="c-navbar__item c-navbar__item--space-right">
-          <a
-            class="c-navbar__item-content c-navbar__clickable c-navbar__clickable--animated "
-            href="/events/"
-            ga-on="click"
-            ga-event-category="navigation"
-            ga-event-action="top nav click"
-            ga-event-label="events"
-            >Events</a
-          >
-        </li>
-        <li class="c-navbar__item c-navbar__item--space-right">
-          <a
-            class="c-navbar__item-content c-navbar__clickable c-navbar__clickable--animated "
-            href="/about/subscribe/"
-            ga-on="click"
-            ga-event-category="subscribe intent"
-            ga-event-action="top nav click"
-            ga-event-label="frontpage"
-            >Newsletters</a
-          >
-        </li>
-        <li class="c-navbar__item ">
-          <a
-            class="c-navbar__item-content c-navbar__clickable c-navbar__clickable--animated"
-            href="https://support.texastribune.org/donate?installmentPeriod=once&amp;amount=60#join-today"
-            ga-on="click"
-            ga-event-category="donations"
-            ga-event-action="membership-intent"
-            ga-event-label="c-navbar"
-            >Donate</a
-          >
-        </li>
-      </ul>
-      <ul id="greeting" class="c-navbar__items js-toggle-on-search ">
-        <ul class="c-navbar__greeting hide_until--l">
-          <li class="c-navbar__item c-navbar__item--space-right">
-            <a
-              href="/accounts/login/?next=/"
-              class="c-navbar__clickable c-navbar__clickable--animated c-navbar__item-content"
-              ><span class="c-icon hide_from--l"><svg aria-hidden="true"><use xlink:href="#sign-in"></use></svg></span>&nbsp;Log In</a
-            >
-          </li>
-        </ul>
-        <li class="c-navbar__item">
-          <button
-            id="nav-search-open"
-            class="c-navbar__item-content c-navbar__clickable"
-            aria-label="Show site search form"
-            ga-on="click"
-            ga-event-category="navigation"
-            ga-event-action="top nav click"
-            ga-event-label="search-open"
-          >
-            <span class="c-icon c-icon--yellow t-size-s">
-              <svg aria-hidden="true">
-                <use xlink:href="#search"></use>
-              </svg>
-            </span>
-          </button>
-        </li>
-      </ul>
-    </div>
-    <div id="nav-search-form" class="c-navbar__search hidden ">
-      <form class="c-navbar__search-form" method="get" action="/search/">
-        <button
-          class="c-navbar__search-button c-navbar__clickable"
-          type="submit"
-          ga-on="click"
-          ga-event-category="navigation"
-          ga-event-action="top nav click"
-          ga-event-label="search-submit"
-        >
-          <span class="c-icon c-icon--yellow">
-            <svg aria-hidden="true">
-              <use xlink:href="#search"></use>
-            </svg>
-          </span>
-        </button>
-        <input
-          class="c-navbar__search-input"
-          name="q"
-          type="text"
-          placeholder="Search The Texas Tribune"
-          aria-label="Search The Texas Tribune"
-        />
-        <button
-          id="nav-search-close"
-          class="c-navbar__clickable"
-          type="button"
-          aria-label="Close site search form"
-          ga-on="click"
-          ga-event-category="navigation"
-          ga-event-action="top nav click"
-          ga-event-label="search-close"
-        >
-          <span class="c-icon c-icon--yellow">
-            <svg aria-hidden="true">
-              <use xlink:href="#close"></use>
-            </svg>
-          </span>
-        </button>
-      </form>
-    </div>
-  </div>
-  <div id="nav-dropdown" class="c-navbar__dropdown hide_from--l hidden">
-    <ul id="mobile-greeting" class="c-navbar__dropdown-items">
-      <li class="c-navbar__dropdown-item">
-        <a
-          class="c-navbar__clickable "
-          href="/our-picks/"
-          ga-on="click"
-          ga-event-category="navigation"
-          ga-event-action="top nav click"
-          ga-event-label="our picks"
-          >Our Picks</a
-        >
-      </li>
-      <li class="c-navbar__dropdown-item">
-        <a
-          class="c-navbar__clickable "
-          href="/series/news-apps-graphics-databases/"
-          ga-on="click"
-          ga-event-category="navigation"
-          ga-event-action="top nav click"
-          ga-event-label="data"
-          >Data</a
-        >
-      </li>
-      <li class="c-navbar__dropdown-item">
-        <a
-          class="c-navbar__clickable "
-          href="/events/"
-          ga-on="click"
-          ga-event-category="navigation"
-          ga-event-action="top nav click"
-          ga-event-label="events"
-          >Events</a
-        >
-      </li>
-      <li class="c-navbar__dropdown-item">
-        <a
-          class="c-navbar__clickable "
-          href="/about/subscribe/"
-          ga-on="click"
-          ga-event-category="subscribe intent"
-          ga-event-action="top nav click"
-          ga-event-label="frontpage"
-          >Newsletters</a
-        >
-      </li>
-      <li class="c-navbar__dropdown-item">
-        <a
-          class="c-navbar__clickable"
-          href="https://support.texastribune.org/donate?installmentPeriod=once&amp;amount=60#join-today"
-          ga-on="click"
-          ga-event-category="donations"
-          ga-event-action="membership-intent"
-          ga-event-label="c-navbar"
-          >Donate</a>
-      </li>
-      <ul class="c-navbar__greeting">
-        <li class="c-navbar__dropdown-item">
-          <a href="/accounts/login/?next=/" class="c-navbar__clickable">
-            <span class="c-icon c-icon--yellow hide_from--l">
-              <svg aria-hidden="true"><use xlink:href="#sign-in"></use></svg>
-            </span>
-            &nbsp;Log In
+          <a href="#"
+            class="c-navbar__item-content c-navbar__clickable c-navbar__clickable--animated t-size-xxs t-uppercase t-uppercase--extra-wide">
+            <strong>Link 4</strong>
           </a>
         </li>
       </ul>
-    </ul>
+
+      <!--
+        You'll need to toggle between "menu" and "close" with some JS
+      -->
+      <ul class="c-navbar__items is-hidden-from-bp-l">
+        <li class="c-navbar__item">
+          <button aria-label="Show menu" class="c-navbar__item-content c-navbar__clickable t-size-xxs t-uppercase t-uppercase--extra-wide">
+            <span class="c-icon">
+              <svg aria-hidden="true" focusable="false">
+                <use xlink:href="#bars"></use>
+              </svg>
+            </span>
+            <strong>&nbsp;Menu</strong>
+          </button>
+        </li>
+        <li class="c-navbar__item is-hidden">
+          <button aria-label="Hide menu" class="c-navbar__item-content c-navbar__clickable t-size-xxs t-uppercase t-uppercase--extra-wide">
+            <span class="c-icon">
+              <svg aria-hidden="true" focusable="false">
+                <use xlink:href="#close"></use>
+              </svg>
+            </span>
+            <strong>&nbsp;Close</strong>
+          </button>
+        </li>
+      </ul>
+    </div>
+
+    <!--
+      You'll need to toggle dropdown visiblity with JS
+    -->
+    <div class="c-navbar__dropdown is-hidden is-hidden-from-bp-l">
+      <ul class="c-navbar__dropdown-items">
+        <li class="c-navbar__dropdown-item">
+          <a href="#" class="is-active c-navbar__clickable t-size-xxs t-uppercase t-uppercase--extra-wide">
+            <strong>Link 1</strong>
+          </a>
+        </li>
+        <li class="c-navbar__dropdown-item">
+          <a href="#" class="c-navbar__clickable t-size-xxs t-uppercase t-uppercase--extra-wide">
+            <strong>Link 2</strong>
+          </a>
+        </li>
+        <li class="c-navbar__dropdown-item">
+          <a href="#" class="c-navbar__clickable t-size-xxs t-uppercase t-uppercase--extra-wide">
+            <strong>Link 3</strong>
+          </a>
+        </li>
+        <li class="c-navbar__dropdown-item">
+          <a href="#" class="c-navbar__clickable t-size-xxs t-uppercase t-uppercase--extra-wide">
+            <strong>Link 4</strong>
+          </a>
+        </li>
+      </ul>
+    </div>
   </div>
 </nav>


### PR DESCRIPTION
This is very similar to my site-footer PR: bringing our helper class/BEM world to a legacy component. Some notes:

+ There are two variations of the nav now: dark and light. Changing `.c-navbar--dark` to `.c-navbar--light` accomplishes that (along with subbing in the proper Trib logo)
+ You might be thinking, "Why didn't he just use our background- and text-color helpers to accomplish the dark/light difference?" The reason is because it's not that simple. For example, the hover animations on link pseudo elements also change depending on the theme. So I felt this is a scenario where fewer helper classes and true BEM made this code easier to read and manage.
+ I updated the HTML example to be more generic (the existing one was for the home-page nav, which is pretty customized compared to our normal nav).
+ Related to the last point, you'll see some `move to texastribune repo` comments in the SCSS file. There are nav elements -- the site-search form, the greeting -- that are specific to the nav inside `texastribune`. I'd argue those should eventually live in a `6-components/_navbar.scss` file _inside_ that repo. As such, I didn't update the styles on those.
+ That said, absolutely zero rush on bringing this to `texastribune`.