### PR TITLE
Convert l-container to rems and add display sizes

### DIFF
--- a/assets/scss/2-tools/_functions.scss
+++ b/assets/scss/2-tools/_functions.scss
@@ -17,3 +17,17 @@
   
   @return $string;
 }
+
+// @function px-to-rem
+//
+// Convert pixels to rem. EX: `px-to-rem(16px)`
+//
+// $pixel-size = '' - {String} Pixel value to convert (required)
+// $context = $font-root - {String} Substring to replace (defaults to $font-root)
+//
+// Styleguide 2.1.3
+//
+
+@function px-to-rem($pixel-size, $context: $font-root) {
+  @return ($pixel-size / $context) * 1rem;
+} 

--- a/assets/scss/5-typography/_t-size.scss
+++ b/assets/scss/5-typography/_t-size.scss
@@ -2,19 +2,19 @@
 //
 // New utility to help eliminate repitition. {{isHelper}}
 //
-// .t-size-xxxs - .55rem
-// .t-size-xxs - .7rem
-// .t-size-xs - .85rem 
-// .t-size-s - .92rem
-// .t-size-b - 1.1rem
-// .t-size-m - 1.2rem 
-// .t-size-l - 1.5rem 
-// .t-size-xl - 1.75rem
-// .t-size-xxl - 2rem
-// .t-size-giant - 2.5rem
-// .t-size-xxxl - 3rem
+// .t-size-xxxs - xxxs size
+// .t-size-xxs - xxs size
+// .t-size-xs - xs size
+// .t-size-s - s size
+// .t-size-b - b size
+// .t-size-m - m size
+// .t-size-l - l size
+// .t-size-xl - xl size
+// .t-size-xxl - xxl size
+// .t-size-giant - giant size
+// .t-size-xxxl - xxxl size
 //
-// Markup: <p class="{{ className }}">Example</p>
+// Markup: <span class="{{ className }} text-size-demo">Example text</span>
 //
 //
 // Styleguide 5.2.7

--- a/assets/scss/7-layout/_container.scss
+++ b/assets/scss/7-layout/_container.scss
@@ -13,15 +13,16 @@
 // Styleguide 7.0.1
 //
 .l-container {
-  max-width: 960px;
-  margin: 0 auto;
+  max-width: px-to-rem($bp-default);
+  margin-left: auto;
+  margin-right: auto;
 }
 
 @each $size-label, $value in $mq-breakpoints {
   $label: str-replace($size-label, 'bp-', '');
   @if $size-label != 'default'  {
     .l-container--#{$label} {
-      max-width: $value;
+      max-width: px-to-rem($value);
     }
   }
   

--- a/assets/scss/7-layout/_grid.scss
+++ b/assets/scss/7-layout/_grid.scss
@@ -87,12 +87,6 @@ $column-slug: col !default;
   display: flex;
   flex-wrap: wrap;
 
-  &_container {
-    margin-left: auto;
-    margin-right: auto;
-    max-width: $bp-default;
-  }
-
   // .grid_row
   // force flex items into a row
   &_row {

--- a/assets/scss/7-layout/container.html
+++ b/assets/scss/7-layout/container.html
@@ -1,1 +1,1 @@
-<div style="border: 2px solid black" class="l-container {{ className }} has-padding">{% if className %}{{ className }}{% else %}Default{%endif%}</div>
+<div style="border: 2px solid black" class="l-container {{ className }} has-padding"><strong>l-container {% if className %}{{ className }}{%endif%}</strong> (<span></span>)</div>

--- a/assets/scss/utilities/_spacing.scss
+++ b/assets/scss/utilities/_spacing.scss
@@ -14,7 +14,7 @@
 // .has-xxs-btm-marg -  Margin bottom with $size-xxs
 // .has-xxxs-btm-marg -  Margin bottom with $size-xxxs
 //
-// Markup: <ul><li class="{{ className }}" style="border:2px solid black;">Example</li><li style="border:2px solid black;">Example</li></ul>
+// Markup: <ul><li class="{{ className }} margin-demo" style="border:2px solid black;">Example</li><li style="border:2px solid black;">Example</li></ul>
 //
 //
 // Styleguide 8.0.1

--- a/docs/src/js/ds.js
+++ b/docs/src/js/ds.js
@@ -5,34 +5,37 @@ showLegacy.addEventListener('click', function() {
   this.classList.toggle('is-active');
 });
 
+var baseFontSize = parseFloat(
+  window.getComputedStyle(document.documentElement).fontSize
+);
+
+function getSizes(el, prop) {
+  var compStyles = window.getComputedStyle(el);
+  var px = compStyles.getPropertyValue(prop);
+  var rems = parseFloat(px) / baseFontSize;
+  rems = parseFloat(rems.toFixed(3));
+  rems = rems.toString();
+  return `${prop}: ${rems}rem | ${px}`;
+}
+
 // inject t-size-<size> font-size
 var textBlocks = document.querySelectorAll('.text-size-demo');
-textBlocks.forEach(textBlock => {
-  var compStyles = window.getComputedStyle(textBlock);
-  var calcSize = compStyles.getPropertyValue('font-size');
-  var fontSetting =
-    parseFloat(calcSize) /
-    parseFloat(window.getComputedStyle(document.documentElement).fontSize);
-  var parentTextBlock = textBlock.parentNode.parentNode;
-  if (typeof parentTextBlock !== 'undefined') {
-    var div = parentTextBlock.querySelector('p');
-    var remVal = parseFloat(fontSetting.toFixed(3));
-    remVal = remVal.toString();
-    div.textContent = `font-size: ${remVal}rem | ${calcSize}`;
-  }
+textBlocks.forEach(el => {
+  var parentEl = el.parentNode.parentElement;
+  var p = parentEl.querySelector('p');
+  p.textContent = getSizes(el, 'font-size');
 });
 
 // inject l-container-<size> max-width
 var containers = document.querySelectorAll('.l-container');
-containers.forEach(container => {
-  var compStyles = window.getComputedStyle(container);
-  var maxWidth = compStyles.getPropertyValue('max-width');
-  var maxWidthSetting =
-    parseFloat(maxWidth) /
-    parseFloat(window.getComputedStyle(document.documentElement).fontSize);
-  container.querySelector(
-    'span'
-  ).textContent = `~ max-width: ${maxWidthSetting.toPrecision(
-    3
-  )}rem | ${maxWidth}`;
+containers.forEach(el => {
+  el.querySelector('span').textContent = getSizes(el, 'max-width');
+});
+
+// inject has-<size>-btm-marg max-width
+var marginHelpers = document.querySelectorAll('.margin-demo');
+marginHelpers.forEach(el => {
+  var parentEl = el.parentNode.parentNode.parentElement;
+  var p = parentEl.querySelector('p');
+  p.textContent = getSizes(el, 'margin-bottom');
 });

--- a/docs/src/js/ds.js
+++ b/docs/src/js/ds.js
@@ -1,5 +1,38 @@
+// toggle legacy styles
 var showLegacy = document.querySelector('#showLegacy');
 showLegacy.addEventListener('click', function() {
   document.body.classList.toggle('js-ds-show-legacy');
   this.classList.toggle('is-active');
+});
+
+// inject t-size-<size> font-size
+var textBlocks = document.querySelectorAll('.text-size-demo');
+textBlocks.forEach(textBlock => {
+  var compStyles = window.getComputedStyle(textBlock);
+  var calcSize = compStyles.getPropertyValue('font-size');
+  var fontSetting =
+    parseFloat(calcSize) /
+    parseFloat(window.getComputedStyle(document.documentElement).fontSize);
+  var parentTextBlock = textBlock.parentNode.parentNode;
+  if (typeof parentTextBlock !== 'undefined') {
+    var div = parentTextBlock.querySelector('p');
+    var remVal = parseFloat(fontSetting.toFixed(3));
+    remVal = remVal.toString();
+    div.textContent = `font-size: ${remVal}rem | ${calcSize}`;
+  }
+});
+
+// inject l-container-<size> max-width
+var containers = document.querySelectorAll('.l-container');
+containers.forEach(container => {
+  var compStyles = window.getComputedStyle(container);
+  var maxWidth = compStyles.getPropertyValue('max-width');
+  var maxWidthSetting =
+    parseFloat(maxWidth) /
+    parseFloat(window.getComputedStyle(document.documentElement).fontSize);
+  container.querySelector(
+    'span'
+  ).textContent = `~ max-width: ${maxWidthSetting.toPrecision(
+    3
+  )}rem | ${maxWidth}`;
 });


### PR DESCRIPTION
- Changes l-container to a rem value. I think changing the variable values directly comes later after we switch to 62.5%.
- Injects size variable values for the `t-size-<size>`, `l-container-<size>`, and `has-<size>-btm-marg` into our docs with some hackyish JS. I wanted a quick way to peek at the calculated values. (I think designers communicate in pixels too, so I was thinking it might aid in translation of design feedback.)

