### PR TITLE
Add even smaller option for has-<size>-btm-marg

### DIFF
--- a/assets/scss/1-settings/_measures.scss
+++ b/assets/scss/1-settings/_measures.scss
@@ -49,6 +49,7 @@ $mq-breakpoints: (
 // $size-xs = .85rem - size xs
 // $size-xxs = .7rem - size xxs
 // $size-xxxs = .55rem - size xxxs
+// $size-tiny = .275rem - size tiny (only used for margin)
 //
 //
 // Styleguide 1.3.3
@@ -65,6 +66,7 @@ $size-s: .92rem;
 $size-xs: .85rem;
 $size-xxs: .7rem;
 $size-xxxs: .55rem;
+$size-tiny: $size-b / 4;
 
 // Map of all sizes for easy iteration
 $size-map: (
@@ -80,6 +82,10 @@ $size-map: (
   xxs: $size-xxs,
   xxxs: $size-xxxs,
 );
+
+// Margin map
+$tiny-map: (tiny: $size-tiny);
+$margin-map: map-merge($size-map, $tiny-map);
 
 // Animation breakpoints
 $animation-single-line-bp: 400px;

--- a/assets/scss/6-components/site-footer/_site-footer.scss
+++ b/assets/scss/6-components/site-footer/_site-footer.scss
@@ -13,9 +13,8 @@
     letter-spacing: .08em;
   }
 
-  &__links {
-    // remove when part of base ul style
-    list-style: none;
+  &__icon {
+    margin-right: $size-xxxs;
   }
 
   a {

--- a/assets/scss/6-components/site-footer/site-footer.html
+++ b/assets/scss/6-components/site-footer/site-footer.html
@@ -1,12 +1,10 @@
 <div class="c-site-footer has-bg-black-off">
   <!--
-    Eventually replace grid_container--xl with l-container--xl
-
     Our various sites will have different variations on the footer
     with different links, number of columns, etc. You'll likely need
     to implement a grid system at the app level to handle those scenarios.
   -->
-  <div class="c-site-footer__inner grid_container--xl grid_row">
+  <div class="c-site-footer__inner l-container l-container--xl grid_row">
     <div class="col">
       <div class="has-b-btm-marg">
         <span style="font-size: 4rem;" class="c-icon has-text-yellow">
@@ -19,8 +17,8 @@
       <div class="has-notch has-notch--thin has-bg-yellow has-b-btm-marg" aria-hidden="true"></div>
       
       <ul class="c-site-footer__links t-size-xs has-text-white has-text-hover-white">
-        <li class="has-xxxs-btm-marg"><a class="has-text-blue has-text-hover-blue" href="https://support.texastribune.org/donate">Donate</a></li>
-        <li class="has-xxxs-btm-marg"><a href="https://www.texastribune.org/contact/">Contact Us</a></li>
+        <li class="has-tiny-btm-marg"><a class="has-text-blue has-text-hover-blue" href="https://support.texastribune.org/donate">Donate</a></li>
+        <li class="has-tiny-btm-marg"><a href="https://www.texastribune.org/contact/">Contact Us</a></li>
         <li>&copy; 2019 The Texas Tribune</li>
       </ul>
     </div>
@@ -29,10 +27,10 @@
       <!-- no need for the <strong> tags anywhere but here; we're using them to override a theme -->
       <h5 class="c-site-footer__header has-text-yellow t-uppercase has-xs-btm-marg"><strong>Heading</strong></h5>
       <ul class="c-site-footer__links has-text-white has-text-hover-white">
-        <li class="has-xxxs-btm-marg"><a href="#">Foo</a></li>
-        <li class="has-xxxs-btm-marg"><a href="#">Bar</a></li>
-        <li class="has-xxxs-btm-marg"><a href="#">Baz</a></li>
-        <li class="has-xxxs-btm-marg"><a href="#">Hello</a></li>
+        <li class="has-tiny-btm-marg"><a href="#">Foo</a></li>
+        <li class="has-tiny-btm-marg"><a href="#">Bar</a></li>
+        <li class="has-tiny-btm-marg"><a href="#">Baz</a></li>
+        <li class="has-tiny-btm-marg"><a href="#">Hello</a></li>
         <li><a href="#">World</a></li>
       </ul>
     </div>
@@ -40,39 +38,39 @@
     <div class="col t-size-xs">
       <h5 class="c-site-footer__header has-text-yellow t-uppercase has-xs-btm-marg"><strong>Heading</strong></h5>
       <ul class="c-site-footer__links has-text-white has-text-hover-white">
-        <li class="has-xxxs-btm-marg"><a href="#">Foo</a></li>
-        <li class="has-xxxs-btm-marg"><a href="#">Bar</a></li>
-        <li class="has-xxxs-btm-marg"><a href="#">Baz</a></li>
-        <li class="has-xxxs-btm-marg"><a href="#">Hello</a></li>
-        <li class="has-xxxs-btm-marg"><a href="#">World</a></li>
+        <li class="has-tiny-btm-marg"><a href="#">Foo</a></li>
+        <li class="has-tiny-btm-marg"><a href="#">Bar</a></li>
+        <li class="has-tiny-btm-marg"><a href="#">Baz</a></li>
+        <li class="has-tiny-btm-marg"><a href="#">Hello</a></li>
+        <li class="has-tiny-btm-marg"><a href="#">World</a></li>
       </ul>
     </div>
     
     <div class="col t-size-xs">
       <h5 class="c-site-footer__header has-text-yellow t-uppercase has-xs-btm-marg"><strong>Social Media</strong></h5>
       <ul class="c-site-footer__links has-b-btm-marg has-text-white has-text-hover-white">
-        <li class="has-xxxs-btm-marg">
-          <span class="t-size-s c-icon c-icon--baseline"><svg aria-hidden="true"><use xlink:href="#facebook"></use></svg></span>
+        <li class="has-tiny-btm-marg">
+          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon"><svg aria-hidden="true"><use xlink:href="#facebook"></use></svg></span>
           <a href="http://facebook.com/texastribune">Facebook</a>
         </li>
-        <li class="has-xxxs-btm-marg">
-          <span class="t-size-s c-icon c-icon--baseline"><svg aria-hidden="true"><use xlink:href="#twitter"></use></svg></span>
+        <li class="has-tiny-btm-marg">
+          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon"><svg aria-hidden="true"><use xlink:href="#twitter"></use></svg></span>
           <a href="http://twitter.com/texastribune">Twitter</a>
         </li>
-        <li class="has-xxxs-btm-marg">
-          <span class="t-size-s c-icon c-icon--baseline"><svg aria-hidden="true"><use xlink:href="#youtube"></use></svg></span>
+        <li class="has-tiny-btm-marg">
+          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon"><svg aria-hidden="true"><use xlink:href="#youtube"></use></svg></span>
           <a href="http://youtube.com/user/thetexastribune?sub_confirmation=1">YouTube</a>
         </li>
-        <li class="has-xxxs-btm-marg">
-          <span class="t-size-s c-icon c-icon--baseline"><svg aria-hidden="true"><use xlink:href="#instagram"></use></svg></span>
+        <li class="has-tiny-btm-marg">
+          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon"><svg aria-hidden="true"><use xlink:href="#instagram"></use></svg></span>
           <a href="http://instagram.com/texas_tribune">Instagram</a>
         </li>
-        <li class="has-xxxs-btm-marg">
-          <span class="t-size-s c-icon c-icon--baseline"><svg aria-hidden="true"><use xlink:href="#linkedin"></use></svg></span>
+        <li class="has-tiny-btm-marg">
+          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon"><svg aria-hidden="true"><use xlink:href="#linkedin"></use></svg></span>
           <a href="http://www.linkedin.com/company/texas-tribune">LinkedIn</a>
         </li>
         <li>
-          <span class="t-size-s c-icon c-icon--baseline"><svg aria-hidden="true"><use xlink:href="#reddit"></use></svg></span>
+          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon"><svg aria-hidden="true"><use xlink:href="#reddit"></use></svg></span>
           <a href="https://www.reddit.com/user/texastribune">Reddit</a>
         </li>
       </ul>
@@ -82,7 +80,7 @@
       <ul class="c-site-footer__links has-text-white has-text-hover-white">
         <li>
           <a href="https://www.facebook.com/groups/thisisyourtexas/">
-            <span class="t-size-s c-icon c-icon--baseline">
+            <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon">
               <svg aria-hidden="true"><use xlink:href="#your-texas"></use></svg></span>
               Join our Facebook Group, This Is Your Texas.
           </a>

--- a/assets/scss/7-layout/container.html
+++ b/assets/scss/7-layout/container.html
@@ -1,1 +1,1 @@
-<div style="border: 2px solid black" class="l-container {{ className }} has-padding"><strong>l-container {% if className %}{{ className }}{%endif%}</strong> (<span></span>)</div>
+<div style="border: 2px solid black" class="l-container {{ className }} has-padding container-demo"><strong>l-container {% if className %}{{ className }}{%endif%}</strong> (<span></span>)</div>

--- a/assets/scss/utilities/_spacing.scss
+++ b/assets/scss/utilities/_spacing.scss
@@ -13,13 +13,16 @@
 // .has-xs-btm-marg -  Margin bottom with $size-xs
 // .has-xxs-btm-marg -  Margin bottom with $size-xxs
 // .has-xxxs-btm-marg -  Margin bottom with $size-xxxs
+// .has-tiny-btm-marg -  Margin bottom with $size-tiny
 //
 // Markup: <ul><li class="{{ className }} margin-demo" style="border:2px solid black;">Example</li><li style="border:2px solid black;">Example</li></ul>
 //
 //
 // Styleguide 8.0.1
 //
-@each $size-name, $size-value in $size-map {
+
+// hack - We need one more size for very small margins but only for margins
+@each $size-name, $size-value in $margin-map {
   .has-#{$size-name}-btm-marg {
     margin-bottom: $size-value;
   }

--- a/docs/src/js/ds.js
+++ b/docs/src/js/ds.js
@@ -29,7 +29,7 @@ textBlocks.forEach(el => {
 });
 
 // inject l-container-<size> max-width
-var containers = document.querySelectorAll('.l-container');
+var containers = document.querySelectorAll('.container-demo');
 containers.forEach(el => {
   el.querySelector('span').textContent = getSizes(el, 'max-width');
 });


### PR DESCRIPTION
I've been missing that [`grid_separator--xs`](https://github.com/texastribune/ds-toolbox/blob/master/assets/scss/7-layout/_grid-legacy.scss#L148-L158) from old world. I've been trying to account for teeny tiny margin-bottoms with line-height, but that was silly [as you saw](https://github.com/texastribune/donations/pull/224#issuecomment-499268469). 
I like how the new world version stays true to our size map in keeping the class names tied to our map labels and respective rem values.
I don't think this tiny unit will be needed in anything other than margins - aka def not needed for text. Creating a new margin-map as an extension of our size-map will allow us to lessen the impact of adding one more size and give us that flexibility of teeny tiny spacers.

FWIW `grid_separator--xs` is used 16 times in /texastribune, so it's going to rear its tiny head at some point some point when we go to replace. 😆

And yeah I'm not a fan of `tiny` as a name but `xxxxs` seems eww right? 
