### PR TITLE
Add some components for story pages

### DIFF
--- a/assets/scss/1-settings/_measures.scss
+++ b/assets/scss/1-settings/_measures.scss
@@ -33,6 +33,19 @@ $mq-breakpoints: (
   bp-default: $bp-default
 );
 
+// Story Containers
+//
+// Our stories have varying containers on them. There is a bit of overlap with our `$mq-breakpoints`; in the future, we might consider revisiting these.
+//
+// $story-small = 30rem - This is our smallest story container; used for plugins
+// $story-narrow = 41.5rem - This is the text story container; used for text and plugins
+// $story-giant = 60rem - This is our widest story container; used for plugins
+//
+// Styleguide 1.3.1
+$story-small: 30rem;
+$story-narrow: 41.5rem;
+$story-giant: 60rem;
+
 
 // Size units
 //

--- a/assets/scss/4-elements/_all.scss
+++ b/assets/scss/4-elements/_all.scss
@@ -24,7 +24,9 @@ h3,
 h4,
 h5,
 h6,
-p {
+p,
+figure,
+blockquote {
   margin: 0;
   padding: 0;
 }
@@ -47,4 +49,8 @@ button {
 // No bullets by default
 ul {
   list-style: none;
+}
+
+hr {
+  border: 1px solid $color-gray-light;
 }

--- a/assets/scss/6-components/_all.scss
+++ b/assets/scss/6-components/_all.scss
@@ -15,8 +15,6 @@
 @import 'list/list';
 @import 'loading/loading';
 @import 'navbar/navbar';
-@import 'plugin/plugin';
-@import 'plugin2/plugin2';
 @import 'share/share';
 @import 'site-footer/site-footer';
 @import 'sponsor-card/sponsor-card';

--- a/assets/scss/6-components/_all.scss
+++ b/assets/scss/6-components/_all.scss
@@ -7,6 +7,7 @@
 @import 'back-to-top/back-to-top';
 @import 'button/button';
 @import 'card/card';
+@import 'caption/caption';
 @import 'full-page-loader/full-page-loader';
 @import 'icon/icon';
 @import 'info-drop/info-drop';
@@ -14,7 +15,11 @@
 @import 'list/list';
 @import 'loading/loading';
 @import 'navbar/navbar';
+@import 'plugin/plugin';
+@import 'plugin2/plugin2';
+@import 'share/share';
 @import 'site-footer/site-footer';
 @import 'sponsor-card/sponsor-card';
+@import 'story-body/story-body';
 @import 'table/table';
 @import 'tabs/tabs';

--- a/assets/scss/6-components/button/_button.scss
+++ b/assets/scss/6-components/button/_button.scss
@@ -6,7 +6,7 @@
 // .c-button--s - One step down from default
 // .c-button--xs - Two steps down from default
 // .c-button--circle - Circular button (experimentally used for back to top)
-// .c-button--circle-responsive - Adapts to parent container
+// .c-button--outline - Hover effect of outline (used on social)
 //
 // Markup: 6-components/button/button.html
 //
@@ -21,12 +21,15 @@
   padding: $size-xs;
   text-align: center;
   text-transform: uppercase;
-  transition: opacity .3s;
+  transition: opacity 0.3s;
 
-  &:hover, &:active {
-    opacity: .7;
+  @media (hover: hover) {
+    &:hover,
+    &:active {
+      opacity: 0.7;
+    }
   }
-  
+
   &--l {
     font-size: $size-l;
     padding: $size-l;
@@ -49,11 +52,26 @@
     position: relative;
   }
 
-  &--circle-responsive {
-    border-radius: 50%;
-    width: 100%;
-    padding-bottom: 100%;
-    position: relative;
+  &__inner {
+    color: #fff;
+  }
+
+  &--outline {
+    border: 2px solid currentColor;
+    transition: background-color 0.3s;
+
+    @media (hover: hover) {
+      &:hover,
+      &:active {
+        background-color: #fff;
+        color: currentColor;
+        opacity: 1;
+
+        .c-button__inner {
+          color: currentColor;
+        }
+      }
+    }
   }
 }
 

--- a/assets/scss/6-components/button/button.html
+++ b/assets/scss/6-components/button/button.html
@@ -6,6 +6,12 @@ Use with vertical centering helper. <code>.l-align-center-y</code>
         <use xlink:href="#arrow-up"></use>
     </svg></span>Back to Top</span>
 </button>
+{% elif className === 'c-button--outline' %}
+<button class="c-button c-button--outline has-text-facebook has-bg-facebook has-text-hover-facebook l-align-center-children">
+    <span class="c-button__inner c-icon"><svg aria-hidden="true">
+        <use xlink:href="#facebook"></use>
+    </svg></span
+</button>
 {% else %}
 <button class="c-button {{ className }}">
     Button

--- a/assets/scss/6-components/caption/_caption.scss
+++ b/assets/scss/6-components/caption/_caption.scss
@@ -1,0 +1,25 @@
+// Caption (c-caption)
+//
+// This is a block of text, which gives context to media. We generally use helper classes for text styles and use this component simply for spacing.
+//
+// c-caption--wide - The removal of padding comes a bit sooner.
+//
+// Markup: 6-components/caption/caption.html
+//
+// Styleguide 6.0.1
+.c-caption {
+  margin: -5px 0 0 0; // not sure what this accounts for (copied from base)
+  padding: $size-xs;
+
+  @include mq($from: bp-xl) {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  &--wide {
+    @include mq($from: bp-m) {
+      padding-left: 0;
+      padding-right: 0;
+    }
+  }
+}

--- a/assets/scss/6-components/caption/caption.html
+++ b/assets/scss/6-components/caption/caption.html
@@ -1,7 +1,10 @@
-<img
+<figure>
+  <img
   class="l-display-block l-width-full"
   src="https://picsum.photos/800/420?random"
-/>
-<figcaption class="c-caption {{className}} has-text-gray-dark l-display-block t-size-xs">
+  alt="Example image"
+  />
+  <figcaption class="c-caption {{className}} has-text-gray-dark l-display-block t-size-xs">
   This is an image caption describing the image above. <span class="c-icon c-icon--baseline"><svg aria-hidden="true"><use xlink:href="#camera"></use></svg></span> <cite>Photographer Name for Company XYZ</cite>
-</figcaption>
+  </figcaption>
+</figure>

--- a/assets/scss/6-components/caption/caption.html
+++ b/assets/scss/6-components/caption/caption.html
@@ -1,0 +1,7 @@
+<img
+  class="l-display-block l-width-full"
+  src="https://picsum.photos/800/420?random"
+/>
+<figcaption class="c-caption {{className}} has-text-gray-dark l-display-block t-size-xs">
+  This is an image caption describing the image above. <span class="c-icon c-icon--baseline"><svg aria-hidden="true"><use xlink:href="#camera"></use></svg></span> <cite>Photographer Name for Company XYZ</cite>
+</figcaption>

--- a/assets/scss/6-components/share/_share.scss
+++ b/assets/scss/6-components/share/_share.scss
@@ -1,0 +1,17 @@
+// Share (c-share)
+//
+// Grid of social share buttons. Typically the "Republish" button is only used on desktop.
+//
+// Markup: 6-components/share/share.html
+//
+// Styleguide 6.0.1
+$share-height: $size-l;
+$share-width: $size-xxxl;
+$share-gap: $size-m;
+
+.c-share {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax($share-width, 1fr));
+  grid-template-rows: repeat(auto-fit, minmax($share-height, 1fr));
+  grid-gap: $share-gap;
+}

--- a/assets/scss/6-components/share/share.html
+++ b/assets/scss/6-components/share/share.html
@@ -1,0 +1,30 @@
+<div class="c-share t-align-center t-size-s">
+  <a 
+    class="c-button c-button--outline has-text-facebook has-bg-facebook has-text-hover-facebook l-align-center-children has-reset-padding" href="#" aria-label="Share on Facebook">
+      <span class="c-button__inner c-icon"><svg aria-hidden="true">
+        <use xlink:href="#facebook"></use>
+      </svg></span>
+  </a>
+  <a 
+    class="c-button c-button--outline has-text-twitter has-bg-twitter has-text-hover-twitter l-align-center-children has-reset-padding" href="#" aria-label="Share on Twitter">
+      <span class="c-button__inner c-icon"><svg aria-hidden="true">
+        <use xlink:href="#twitter"></use>
+      </svg></span>
+  </a>
+  <a 
+    class="c-button c-button--outline has-text-yellow has-bg-yellow has-text-hover-yellow l-align-center-children has-reset-padding" href="#" aria-label="Share this story by email">
+      <span class="c-button__inner c-icon"><svg aria-hidden="true">
+        <use xlink:href="#envelope"></use>
+      </svg></span>
+  </a>
+  <a 
+    class="c-button c-button--outline has-text-teal has-bg-teal has-text-hover-teal l-align-center-children has-reset-padding" href="#" aria-label="View comments">
+      <span class="c-button__inner c-icon"><svg aria-hidden="true">
+        <use xlink:href="#comments"></use>
+      </svg></span>
+  </a>
+  <a 
+    class="c-button c-button--outline has-text-gray has-bg-gray has-text-hover-gray is-hidden-until-bp-s l-align-center-children has-reset-padding" href="#" aria-label="Republish this story">
+      <span class="c-button__inner t-size-xxs">Republish</span>
+  </a>
+</div>

--- a/assets/scss/6-components/story-body/_story-body.scss
+++ b/assets/scss/6-components/story-body/_story-body.scss
@@ -7,8 +7,15 @@
 // Styleguide 6.1.3
 
 .c-story-body {
-  // this is probably crazy
-  > *:not(.plugin) {
+  > p,
+  > h2,
+  > h3,
+  > h4,
+  > h5,
+  > h6,
+  > ul,
+  > span,
+  > div:not([class^="plugin"]) {
     max-width: $story-narrow;
     margin: $size-b auto;
     line-height: 1.4;
@@ -17,6 +24,11 @@
   ul {
     list-style: disc;
     padding: 0 $size-b 0 3.5rem;
+    
+  }
+
+  li {
+    margin-bottom: $size-b;
   }
 
   sub, sup {

--- a/assets/scss/6-components/story-body/_story-body.scss
+++ b/assets/scss/6-components/story-body/_story-body.scss
@@ -1,0 +1,25 @@
+// Story Body (c-story-body)
+//
+// Story bodies are a special component because we have limited control over the class names within them. We must deviate from BEM and create catch-all tag selectors to allow the greatest flexibility of the markup.
+//
+// Markup: 6-components/story-body/story-body.html
+//
+// Styleguide 6.1.3
+
+.c-story-body {
+  // this is probably crazy
+  > *:not(.plugin) {
+    max-width: $story-narrow;
+    margin: $size-b auto;
+    line-height: 1.4;
+  }
+
+  ul {
+    list-style: disc;
+    padding: 0 $size-b 0 3.5rem;
+  }
+
+  sub, sup {
+    position: initial;
+  }
+}

--- a/assets/scss/6-components/story-body/story-body.html
+++ b/assets/scss/6-components/story-body/story-body.html
@@ -1,0 +1,20 @@
+<section class="c-story-body has-text-black-off t-linkstyle t-linkstyle--underlined has-l-btm-marg t-serif t-space-heading-m story_body">
+  <p>Our editor outputs blocks of texts with paragraph tags.</p>
+  <h3>Helper classes needed</h3>
+  <p>Note that we also sprinkle in sibling helper classes with story-body.</p>
+  <ul>
+    <li>has-text-black-off</li>
+    <li>t-linkstyle</li>
+    <li>t-linkstyle--underlined</li>
+    <li>has-l-btm-marg</li>
+    <li>t-serif</li>
+    <li>t-space-heading-m</li>
+  </ul>
+  <p>Our editor has a dropdown option called <em>Subheader</em> for adding a heading element. By default, that tag is an h3. In the event someone were to open the source and add others, this is how they would display.</p>
+  <h1>Heading 1</h1>
+  <h2>Heading 2</h2>
+  <h3>Heading 3 - Default</h3>
+  <h4>Heading 4</h4>
+  <h5>Heading 5</h5>
+  <h6>Heading 6</h6>
+</section>

--- a/assets/scss/6-components/story-body/story-body.html
+++ b/assets/scss/6-components/story-body/story-body.html
@@ -1,7 +1,7 @@
-<section class="c-story-body has-text-black-off t-linkstyle t-linkstyle--underlined has-l-btm-marg t-serif t-space-heading-m story_body">
+<section class="c-story-body t-linkstyle t-linkstyle--underlined has-l-btm-marg t-serif t-space-heading-m t-size-b story_body">
   <p>Our editor outputs blocks of texts with paragraph tags.</p>
   <h3>Helper classes needed</h3>
-  <p>Note that we also sprinkle in sibling helper classes with story-body.</p>
+  <p>Note that we also sprinkle in sibling helper classes with story-body. For example, the t-linkstyle helper gives us the ability to style <a href="#">links like this.</a></p>
   <ul>
     <li>has-text-black-off</li>
     <li>t-linkstyle</li>
@@ -11,10 +11,12 @@
     <li>t-space-heading-m</li>
   </ul>
   <p>Our editor has a dropdown option called <em>Subheader</em> for adding a heading element. By default, that tag is an h3. In the event someone were to open the source and add others, this is how they would display.</p>
-  <h1>Heading 1</h1>
   <h2>Heading 2</h2>
   <h3>Heading 3 - Default</h3>
   <h4>Heading 4</h4>
   <h5>Heading 5</h5>
   <h6>Heading 6</h6>
+  <div class="has-padding has-bg-yellow">Example of rouge div</div>
+  <div class="plugin has-padding has-bg-gray-light">Example of plugin. Should be not be bound by container.</div>
+  <div class="plugin-ad has-padding has-bg-gray-light">Example of ad plugin. Should be not be bound by container</div>
 </section>

--- a/assets/scss/7-layout/_align.scss
+++ b/assets/scss/7-layout/_align.scss
@@ -5,6 +5,7 @@
 // l-align-center-x - Uses auto side margin for **horizontal** center
 // l-align-center-y - Absolutely positioned for vertical **vertical** center
 // l-align-center-self - Used on children of flex parent for **vertical** center
+// l-align-center-children - Apply to parent to center children. Centers x and y.
 //
 // Markup: 7-layout/align.html
 //
@@ -27,4 +28,10 @@
 // apply to an item with a flex parent
 .l-align-center-self {
   align-self: center;
+}
+
+.l-align-center-children {
+  align-items: center;
+  display: flex;
+  justify-content: center;
 }

--- a/assets/scss/7-layout/align.html
+++ b/assets/scss/7-layout/align.html
@@ -1,4 +1,4 @@
-<div style="border:2px solid black; width: 200px; height: 100px; position: relative; {% if className == 'l-align-center-self' %}display: flex{% endif %}">
+<div style="border:2px solid black; width: 200px; height: 100px; position: relative; {% if className == 'l-align-center-self' %}display: flex{% endif %}" {% if className == 'l-align-center-children' %}class="{{className}}"{% endif %}>
   <div style="width: 50%;" class="has-padding has-bg-yellow {{className}}">Example</div>
 </div>
 {% if className == 'l-align-center-self' %}Parent is display: flex{% endif %}

--- a/assets/scss/utilities/_color-helpers.scss
+++ b/assets/scss/utilities/_color-helpers.scss
@@ -81,6 +81,8 @@ $color-map: (
   "blue-dark": $color-blue-dark,
   "error": $color-error,
   "sponsor": $color-sponsor,
+  "twitter": $color-twitter,
+  "facebook": $color-facebook,
 );
 
 @each $color, $value in $color-map {

--- a/assets/scss/utilities/_spacing.scss
+++ b/assets/scss/utilities/_spacing.scss
@@ -35,6 +35,7 @@
 // .has-padding -  All-around padding with $size-b
 // .has-xs-padding -  All-around padding with $size-xs
 // .has-xl-padding -  All-around padding with $size-xl
+// .has-reset-padding -  Removes padding
 //
 // Markup: <div style="background:#ffc200;" class="{{ className }}">Example</div>
 //
@@ -51,4 +52,8 @@
 
 .has-xl-padding {
   padding: $size-xl;
+}
+
+.has-reset-padding {
+  padding: 0;
 }

--- a/docs/src/preview-raw.html
+++ b/docs/src/preview-raw.html
@@ -1,12 +1,15 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="fonts-loaded">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>{{mainClass}} | Standalone</title>
 </head>
-<body style="margin: 20px;">
+<body style="margin: 20px;border:1px dashed gray">
+<div style="display: none">
+  {% include '../dist/sprites/base.html' %}
+</div>
 <!-- {{ mainClass }} -->
 <section style="margin-bottom: 20px">
 {% if isFile %}


### PR DESCRIPTION
Preview with:
`yarn dev-docs`

**globals added**
- `figure` and `blockquote` - remove default margin/padding
- `hr` - Typically the default for hr borders is `border-style: inset`. That is silly. Solid and our own gray variable FTW.

**utilities classes added:**

- `has-reset-padding` - I ended up needing the `c-button` class without any padding. This reset felt more versatile than a reset scoped to c-button.
- _color helpers_
     - `has-text-facebook`|`has-bg-facebook`|`has-text-hover-facebook`
     - `has-text-twitter`|`has-bg-twitter`|`has-text-hover-twitter`
     - I went back and forth on this one, but I think in those few places we're we add the social colors, we'd end up with almost 6 new declarations anyhow. This also made the `c-button--outline` approach possible.

**layout classes added:**

- `l-align-center-children` - Needed this to align an icon in a button. Again, it seemed more useful as a generic helper rather than a button variation.

**component classes added:**

- `c-button--outline` - I wanted to see if a mixture of currentColor and our color helpers could achieve that hover outline effect. I found a somewhat minimal approach that avoids having to declare five different colors. I think we said art might let us ditch that hover effect so once they do, we can drop this.

- `c-share` - A basic grid for our share buttons.

- `c-caption` - Gives us that padding logic we need for small devices and full bleed images.

- `c-story-body` - Basically accounts for [story_body.scss](https://github.com/texastribune/texastribune/blob/980b2cc14c6768a8c01b4801b5e71d53c12f145c/snollygoster/common/sass/tt_styles/components/story/_story_body.scss). I thought it might be helpful to use the :not selector to grab any rouge divs that get inserted, while keeping plugins container-free

**component classes removed:**
- `c-button--circle-responsive` - I don't think the circular button is used enough for it to have this option.