### PR TITLE
Remove webkit arrow on c-info-drop

### DIFF
--- a/assets/scss/6-components/info-drop/_info-drop.scss
+++ b/assets/scss/6-components/info-drop/_info-drop.scss
@@ -31,6 +31,10 @@ $info-drop-size: px-to-rem(14px);
     top: 100%;
     width: $info-drop-size * 2;
     z-index: 1;
+    // hide browser arrow
+    &::-webkit-details-marker {
+      display: none;
+    }
   }
 
   &__container {


### PR DESCRIPTION
Removes this extra arrow Chrome injects
<img width="168" alt="Screen Shot 2019-07-11 at 12 36 26 PM" src="https://user-images.githubusercontent.com/2974713/61072261-8ae46c80-a3d8-11e9-86a4-7a5d3fcf3c2c.png">